### PR TITLE
When an aioredis coroutine is wrapped in a cancelled task, the pending call is not cancelled

### DIFF
--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -246,6 +246,7 @@ class RedisFuture(asyncio.Future):
 
     def cancel(self):
         super(RedisFuture, self).cancel()
-        if self._conn._closed:
-            return
-        self._conn._reader_task.cancel()
+        if self._conn._reader_task:
+            self._conn._reader_task.cancel()
+            self._conn._reader_task = asyncio.Task(self._conn._read_data(),
+                                                   loop=self._conn._loop)

--- a/tests/_testutil.py
+++ b/tests/_testutil.py
@@ -25,9 +25,13 @@ def run_until_complete(fun):
     @wraps(fun)
     def wrapper(test, *args, **kw):
         loop = test.loop
-        ret = loop.run_until_complete(
-            asyncio.wait_for(fun(test, *args, **kw), 15, loop=loop))
-        return ret
+        try:
+            ret = loop.run_until_complete(
+                asyncio.wait_for(fun(test, *args, **kw), 15, loop=loop))
+        except asyncio.CancelledError:
+            pass
+        else:
+            return ret
     return wrapper
 
 


### PR DESCRIPTION
When a coroutine is wrapped in a Task that is cancelled, the pending redis call is not cancelled and its result is lost.

Here is an example using ``BLPOP``

``` python
#!/usr/bin/env python

import asyncio
import aioredis


@asyncio.coroutine
def simulate_client():
    redis = yield from aioredis.create_redis(('localhost', 6379))
    print("$ Client sleeps")
    yield from asyncio.sleep(2)
    print("$ Client add task hello")
    yield from redis.lpush("channel", "hello")
    print("$ Client sleeps")    
    yield from asyncio.sleep(10)


@asyncio.coroutine
def simulate_server():
    redis = yield from aioredis.create_redis(('localhost', 6379))
    print("# Wait for task")
    try:
        data = yield from asyncio.wait_for(redis.blpop("channel"), 1)
    except asyncio.TimeoutError:
        print("# BLPOP timed-out")
        yield from asyncio.sleep(5)
        print("# Wait for task")
        try:
            data = yield from asyncio.wait_for(redis.blpop("channel"), 1)
        except asyncio.TimeoutError:
            print("# BLPOP timed-out the task is lost.")
        else:
            print("# BLPOP returned: %s" % data)
    else:
        print("# BLPOP returned: %s" % data)


asyncio.get_event_loop().run_until_complete(
    asyncio.wait({simulate_server(), simulate_client()})
)
```

For this example, I can fix it using the timeout value of BLPOP but I have the same behavior when using it with ``asyncio.wait``

```  python
    yield from asyncio.wait(
                {redis.blpop("channel"), websocket.recv()},
                return_when=asyncio.FIRST_COMPLETED)
```