### PR TITLE
fix : when create_pool has an encoding, hgetall has to return decoding results

### DIFF
--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -143,12 +143,21 @@ class RedisConnection:
             if self._in_transaction:
                 self._transaction_error = obj
         else:
-            if encoding is not None and isinstance(obj, bytes):
-                try:
-                    obj = obj.decode(encoding)
-                except Exception as exc:
-                    waiter.set_exception(exc)
-                    return  # continue
+            if encoding is not None:
+                if isinstance(obj, bytes):
+                    try:
+                        obj = obj.decode(encoding)
+                    except Exception as exc:
+                        waiter.set_exception(exc)
+                        return  # continue
+                elif isinstance(obj, list):
+                    try:
+                        obj = [member.decode(encoding)
+                               if isinstance(member, bytes) else member
+                               for member in obj]
+                    except Exception as exc:
+                        waiter.set_exception(exc)
+                        return  # continue
             waiter.set_result(obj)
             if cb is not None:
                 cb(obj)

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -242,6 +242,20 @@ class PoolTest(BaseTest):
             self.assertEqual(res, 'value')
 
     @run_until_complete
+    def test_hgetall_response_decoding(self):
+        pool = yield from self.create_pool(
+            ('localhost', self.redis_port),
+            encoding='utf-8', loop=self.loop)
+
+        self.assertEqual(pool.encoding, 'utf-8')
+        with (yield from pool) as redis:
+            yield from redis.hmset('key1', 'foo', 'bar')
+            yield from redis.hmset('key1', 'baz', 'zap')
+        with (yield from pool) as redis:
+            res = yield from redis.hgetall('key1')
+            self.assertEqual(res, {'foo': 'bar', 'baz': 'zap'})
+
+    @run_until_complete
     def test_crappy_multiexec(self):
         pool = yield from self.create_pool(
             ('localhost', self.redis_port),


### PR DESCRIPTION
At present, Even if create_pool has an encoding, Inevitably, we should write the code for decoding the result of hgetall.

fix about it