### PR TITLE
Pep492

### DIFF
--- a/aioredis/pool.py
+++ b/aioredis/pool.py
@@ -1,8 +1,12 @@
 import asyncio
 import collections
+import sys
 
 from .commands import create_redis, Redis
 from .log import logger
+
+
+PY_35 = sys.version_info >= (3, 5)
 
 
 @asyncio.coroutine
@@ -206,6 +210,12 @@ class RedisPool:
         # this method is needed to allow `yield`ing from pool
         conn = yield from self.acquire()
         return _ConnectionContextManager(self, conn)
+
+    if PY_35:
+        def __await__(self):
+            # this method is needed to allow `await pool`
+            conn = yield from self.acquire()
+            return _ConnectionContextManager(self, conn)
 
 
 class _ConnectionContextManager:

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -338,3 +338,19 @@ class PoolTest(BaseTest):
         ''')
         exec(s, globals(), locals())
         yield from locals()['coro'](self, pool)
+
+    @unittest.skipUnless(PY_35, "Python 3.5+ required")
+    @run_until_complete
+    def test_async_with(self):
+        pool = yield from self.create_pool(
+            ('localhost', self.redis_port),
+            minsize=10, loop=self.loop)
+
+        s = dedent('''\
+        async def coro(testcase, pool):
+            async with pool.get() as conn:
+                msg = await conn.echo('hello')
+                testcase.assertEqual(msg, b'hello')
+        ''')
+        exec(s, globals(), locals())
+        yield from locals()['coro'](self, pool)


### PR DESCRIPTION
1. Fix regression, `with await pool as conn` now works under Python 3.5
2. Add explicit support for async context manager `async with pool.get() as conn`. I doubt is `.get()` the best name but it can be changed easy.