### PR TITLE
Close all pubsub channels when connection is closed

### DIFF
--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -267,7 +267,8 @@ class RedisConnection:
                 waiter.cancel()
             else:
                 waiter.set_exception(exc)
-        # TODO: close all subscribed channels
+        for ch in self._pubsub_channels.values():
+            ch.close()
 
     @property
     def closed(self):

--- a/aioredis/util.py
+++ b/aioredis/util.py
@@ -147,7 +147,8 @@ class Channel:
         self._queue.put_nowait(data)
         if self._waiter is not None:
             fut, self._waiter = self._waiter, None
-            fut.set_result(None)
+            if not fut.cancelled():
+                fut.set_result(None)
 
     def close(self):
         """Marks channel as inactive.


### PR DESCRIPTION
Without this, Channel#wait_message() doesn't return nor raise any exceptions when the connection is lost.