### PR TITLE
Added support for SSL/TLS

### DIFF
--- a/aioredis/commands/__init__.py
+++ b/aioredis/commands/__init__.py
@@ -126,7 +126,7 @@ class Redis(GenericCommandsMixin, StringCommandsMixin,
 
 
 @asyncio.coroutine
-def create_redis(address, *, db=None, password=None,
+def create_redis(address, *, db=None, password=None, ssl=None,
                  encoding=None, commands_factory=Redis,
                  loop=None):
     """Creates high-level Redis interface.
@@ -135,13 +135,14 @@ def create_redis(address, *, db=None, password=None,
     """
     conn = yield from create_connection(address, db=db,
                                         password=password,
+                                        ssl=ssl,
                                         encoding=encoding,
                                         loop=loop)
     return commands_factory(conn)
 
 
 @asyncio.coroutine
-def create_reconnecting_redis(address, *, db=None, password=None,
+def create_reconnecting_redis(address, *, db=None, password=None, ssl=None,
                               encoding=None, commands_factory=Redis,
                               loop=None):
     """Creates high-level Redis interface.
@@ -152,7 +153,7 @@ def create_reconnecting_redis(address, *, db=None, password=None,
     # a first connection in it, or just resolve DNS. So let's keep it
     # coroutine for forward compatibility
     conn = AutoConnector(address,
-                         db=db, password=password,
+                         db=db, password=password, ssl=ssl,
                          encoding=encoding, loop=loop)
     return commands_factory(conn)
 

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -48,9 +48,9 @@ def create_connection(address, *, db=None, password=None, ssl=None,
     * when address is a str it represents unix domain socket path.
     (no other address formats supported)
 
-    SSL argument is passed through to asyncio.create_connection.    
-    By default SSL/TLS is not used. 
-    
+    SSL argument is passed through to asyncio.create_connection.
+    By default SSL/TLS is not used.
+
     Encoding argument can be used to decode byte-replies to strings.
     By default no decoding is done.
 

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -38,7 +38,7 @@ _PUBSUB_COMMANDS = (
 
 
 @asyncio.coroutine
-def create_connection(address, *, db=None, password=None,
+def create_connection(address, *, db=None, password=None, ssl=None,
                       encoding=None, loop=None):
     """Creates redis connection.
 
@@ -48,6 +48,9 @@ def create_connection(address, *, db=None, password=None,
     * when address is a str it represents unix domain socket path.
     (no other address formats supported)
 
+    SSL argument is passed through to asyncio.create_connection.    
+    By default SSL/TLS is not used. 
+    
     Encoding argument can be used to decode byte-replies to strings.
     By default no decoding is done.
 
@@ -61,14 +64,14 @@ def create_connection(address, *, db=None, password=None,
         host, port = address
         logger.debug("Creating tcp connection to %r", address)
         reader, writer = yield from asyncio.open_connection(
-            host, port, loop=loop)
+            host, port, ssl=ssl, loop=loop)
         sock = writer.transport.get_extra_info('socket')
         if sock is not None:
             sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
     else:
         logger.debug("Creating unix connection to %r", address)
         reader, writer = yield from asyncio.open_unix_connection(
-            address, loop=loop)
+            address, ssl=ssl, loop=loop)
     conn = RedisConnection(reader, writer, encoding=encoding, loop=loop)
 
     try:

--- a/aioredis/pool.py
+++ b/aioredis/pool.py
@@ -11,7 +11,7 @@ PY_35 = sys.version_info >= (3, 5)
 
 
 @asyncio.coroutine
-def create_pool(address, *, db=0, password=None, encoding=None,
+def create_pool(address, *, db=0, password=None, ssl=None, encoding=None,
                 minsize=10, maxsize=10, commands_factory=Redis, loop=None):
     """Creates Redis Pool.
 
@@ -24,7 +24,7 @@ def create_pool(address, *, db=0, password=None, encoding=None,
     Returns RedisPool instance.
     """
 
-    pool = RedisPool(address, db, password, encoding,
+    pool = RedisPool(address, db, password, ssl, encoding,
                      minsize=minsize, maxsize=maxsize,
                      commands_factory=commands_factory,
                      loop=loop)
@@ -36,13 +36,14 @@ class RedisPool:
     """Redis connections pool.
     """
 
-    def __init__(self, address, db=0, password=None, encoding=None,
+    def __init__(self, address, db=0, password=None, ssl=None, encoding=None,
                  *, minsize, maxsize, commands_factory, loop=None):
         if loop is None:
             loop = asyncio.get_event_loop()
         self._address = address
         self._db = db
         self._password = password
+        self._ssl = ssl
         self._encoding = encoding
         self._minsize = minsize
         self._factory = commands_factory
@@ -193,6 +194,7 @@ class RedisPool:
         return create_redis(self._address,
                             db=self._db,
                             password=self._password,
+                            ssl=self._ssl,
                             encoding=self._encoding,
                             commands_factory=self._factory,
                             loop=self._loop)

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -32,7 +32,7 @@ Connection usage is as simple as:
    asyncio.get_event_loop().run_until_complete(connection_example())
 
 
-.. function:: create_connection(address, \*, db=0, password=None,\
+.. function:: create_connection(address, \*, db=0, password=None, ssl=None,\
                                 encoding=None, loop=None)
 
    Creates Redis connection.
@@ -48,6 +48,10 @@ Connection usage is as simple as:
    :param password: Password to use if redis server instance requires
                     authorization.
    :type password: str or None
+   
+   :param ssl: SSL context that is passed through to 
+               :func:`asyncio.BaseEventLoop.create_connection`.
+   :type ssl: :class:`ssl.SSLContext` or True or None 
 
    :param encoding: Codec to use for response decoding.
    :type encoding: str or None
@@ -190,9 +194,9 @@ The library provides connections pool. The basic usage is as follows:
 
 .. _aioredis-create_pool:
 
-.. function:: create_pool(address, \*, db=0, password=None, encoding=None, \
-                          minsize=10, maxsize=10, commands_factory=Redis,\
-                          loop=None)
+.. function:: create_pool(address, \*, db=0, password=None, ssl=None, \
+                          encoding=None, minsize=10, maxsize=10, \
+                          commands_factory=Redis, loop=None)
 
    A :ref:`coroutine<coroutine>` that creates Redis connections pool.
 
@@ -209,6 +213,10 @@ The library provides connections pool. The basic usage is as follows:
    :param password: Password to use if redis server instance requires
                     authorization.
    :type password: str or None
+   
+   :param ssl: SSL context that is passed through to 
+               :func:`asyncio.BaseEventLoop.create_connection`.
+   :type ssl: :class:`ssl.SSLContext` or True or None    
 
    :param encoding: Codec to use for response decoding.
    :type encoding: str or None
@@ -395,7 +403,7 @@ Commands Interface
 The library provides high-level API implementing simple interface
 to Redis commands.
 
-.. function:: create_redis(address, \*, db=0, password=None,\
+.. function:: create_redis(address, \*, db=0, password=None, ssl=None,\
                            encoding=None, commands_factory=Redis,\
                            loop=None)
 
@@ -411,6 +419,10 @@ to Redis commands.
    :param password: Password to use if redis server instance requires
                     authorization.
    :type password: str or None
+   
+   :param ssl: SSL context that is passed through to 
+               :func:`asyncio.BaseEventLoop.create_connection`.
+   :type ssl: :class:`ssl.SSLContext` or True or None    
 
    :param encoding: Codec to use for response decoding.
    :type encoding: str or None
@@ -426,7 +438,7 @@ to Redis commands.
 
 
 .. function:: create_reconnecting_redis(address, \*, db=0, password=None,\
-                           encoding=None, commands_factory=Redis,\
+                           ssl=None, encoding=None, commands_factory=Redis,\
                            loop=None)
 
    Like :func:`create_redis` this :ref:`coroutine<coroutine>` creates


### PR DESCRIPTION
[By design](http://redis.io/topics/security), Redis doesn't natively support encryption via SSL/TLS. However, it can be added with an SSL proxy. 

For this reason, [some popular Redis libraries support SSL connections](https://github.com/andymccurdy/redis-py/blob/1c2071762ad9b9288e786665990083e61c1cf355/redis/connection.py#L656).

This change adds support for SSL/TLS by leveraging asyncio's existing SSL support in [asyncio.BaseEventLoop.create_connection](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.BaseEventLoop.create_connection) and using its semantics.

I didn't exhaustively research or test this change, so this pull request is simply my first pass at how such a change might look. I welcome critical feedback on it.

Thanks for this library!