### PR TITLE
Bugfix: Shield close_waiter from cancellation of wait_closed.

### DIFF
--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -311,7 +311,7 @@ class RedisConnection:
 
     @asyncio.coroutine
     def wait_closed(self):
-        yield from self._close_waiter
+        yield from asyncio.shield(self._close_waiter, loop=self._loop)
 
     @property
     def db(self):

--- a/tests/connection_test.py
+++ b/tests/connection_test.py
@@ -161,7 +161,8 @@ class ConnectionTest(BaseTest):
         conn.close()
         task = async_task(conn.wait_closed(), loop=self.loop)
 
-        # Make sure the task is cancelled after it has been started by the loop.
+        # Make sure the task is cancelled
+        # after it has been started by the loop.
         self.loop.call_soon(task.cancel)
 
         yield from conn.wait_closed()

--- a/tests/connection_test.py
+++ b/tests/connection_test.py
@@ -2,7 +2,9 @@ import unittest
 import asyncio
 import os
 
+from aioredis.util import async_task
 from ._testutil import BaseTest, run_until_complete
+
 from aioredis import (
     ConnectionClosedError,
     ProtocolError,
@@ -139,6 +141,31 @@ class ConnectionTest(BaseTest):
             yield from conn.execute_pubsub('subscribe', 'channel:1')
         conn._reader = stored_reader
         conn.close()
+
+    @run_until_complete
+    def test_wait_closed(self):
+        address = ('localhost', self.redis_port)
+        conn = yield from self.create_connection(address, loop=self.loop)
+        reader_task = conn._reader_task
+        conn.close()
+        self.assertFalse(reader_task.done())
+        yield from conn.wait_closed()
+        self.assertTrue(reader_task.done())
+
+    @run_until_complete
+    def test_cancel_wait_closed(self):
+        # Regression test: Don't throw error if wait_closed() is cancelled.
+        address = ('localhost', self.redis_port)
+        conn = yield from self.create_connection(address, loop=self.loop)
+        reader_task = conn._reader_task
+        conn.close()
+        task = async_task(conn.wait_closed(), loop=self.loop)
+
+        # Make sure the task is cancelled after it has been started by the loop.
+        self.loop.call_soon(task.cancel)
+
+        yield from conn.wait_closed()
+        self.assertTrue(reader_task.done())
 
     @run_until_complete
     def test_auth(self):


### PR DESCRIPTION
Otherwise, if an 'await connection.wait_closed()' is cancelled, the _close_waiter will be cancelled, too. This raises an error, because when _read_task is done, it tries to set the result of the already cancelled _close_waiter.