### PR TITLE
redis queue implementation (LPOP, BLPOP, RPUSH, LLEN)

### DIFF
--- a/aioredis/util.py
+++ b/aioredis/util.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import sys
+import uuid
 
 from .errors import ChannelClosedError
 from .log import logger
@@ -8,7 +9,6 @@ from .log import logger
 PY_35 = sys.version_info >= (3, 5)
 
 _NOTSET = object()
-
 
 # NOTE: never put here anything else;
 #       just this basic types
@@ -18,7 +18,7 @@ _converters = {
     str: lambda val: val.encode('utf-8'),
     int: lambda val: str(val).encode('utf-8'),
     float: lambda val: str(val).encode('utf-8'),
-    }
+}
 
 
 def _bytes_len(sized):
@@ -53,6 +53,62 @@ def decode(obj, encoding):
     elif isinstance(obj, list):
         return [decode(o, encoding) for o in obj]
     return obj
+
+
+class Queue:
+
+    def __init__(self, connection, key=uuid.uuid4().hex, max_size=0, timeout=None):
+        self._conn = connection
+        self._key = key
+        self._max_size = max_size
+        self._timeout = timeout
+
+    @property
+    def key(self):
+        return self._key
+
+    @property
+    def max_size(self):
+        return self._max_size
+
+    @asyncio.coroutine
+    def qsize(self):
+        return (yield from self._conn.llen(self._key))
+
+    @asyncio.coroutine
+    def empty(self):
+        return (yield from self.qsize()) == 0
+
+    @asyncio.coroutine
+    def full(self):
+        if self._max_size != 0:
+            return (yield from self.qsize()) >= self._max_size
+        return False
+
+    @asyncio.coroutine
+    def get(self, timeout=None):
+        query_timeout = timeout if timeout else self._timeout
+        item = yield from self._conn.blpop(self._key, timeout=query_timeout)
+        return item
+
+    @asyncio.coroutine
+    def get_nowait(self):
+        item = yield from self._conn.lpop(self._key)
+        return item
+
+    @asyncio.coroutine
+    def put(self, data):
+        if not (yield from self.full()):
+            yield from self._conn.rpush(self._key, data)
+            return True
+        return False
+
+    @asyncio.coroutine
+    def put_nowait(self, data):
+        if not (yield from self.full()):
+            asyncio.ensure_future(self._conn.rpush(self._key, data))
+            return True
+        return False
 
 
 class Channel:
@@ -212,7 +268,6 @@ def wait_make_dict(fut):
 
 
 class coerced_keys_dict(dict):
-
     def __getitem__(self, other):
         if not isinstance(other, bytes):
             other = _converters[type(other)](other)
@@ -237,6 +292,7 @@ if PY_35:
         def __aiter__(self):
             return self
 
+
     class _ScanIter(_BaseScanIter):
 
         @asyncio.coroutine
@@ -248,6 +304,7 @@ if PY_35:
             else:
                 ret = self._ret.pop(0)
                 return ret
+
 
     class _ScanIterPairs(_BaseScanIter):
 
@@ -261,6 +318,7 @@ if PY_35:
             else:
                 ret = self._ret.pop(0)
                 return ret
+
 
     class _ChannelIter:
 
@@ -278,10 +336,10 @@ if PY_35:
         @asyncio.coroutine
         def __anext__(self):
             if not self._ch.is_active:
-                raise StopAsyncIteration    # noqa
+                raise StopAsyncIteration  # noqa
             msg = yield from self._ch.get(*self._args, **self._kw)
             if msg is None:
-                raise StopAsyncIteration    # noqa
+                raise StopAsyncIteration  # noqa
             return msg
 
 

--- a/tests/queue_test.py
+++ b/tests/queue_test.py
@@ -1,0 +1,58 @@
+import uuid
+import time
+import asyncio
+import unittest
+from textwrap import dedent
+from ._testutil import RedisTest, run_until_complete
+from aioredis import RedisPool, ReplyError
+from aioredis.util import Queue
+
+
+class QueueTest(RedisTest):
+
+    @run_until_complete
+    def test_put_get(self):
+        queue = Queue(connection=self.redis)
+        self.assertTrue((yield from queue.empty()))
+        self.assertFalse((yield from queue.get_nowait()))
+        data = uuid.uuid4().bytes
+        data2 = uuid.uuid4().bytes
+        self.assertTrue((yield from queue.put(data)))
+        self.assertEqual((yield from queue.qsize()), 1)
+        self.assertTrue((yield from queue.put(data2)))
+        self.assertEqual((yield from queue.qsize()), 2)
+        self.assertEqual((yield from queue.get_nowait()), data)
+        self.assertEqual((yield from queue.get_nowait()), data2)
+        self.assertTrue((yield from queue.empty()))
+
+    @run_until_complete
+    def test_queue_size(self):
+        queue = Queue(connection=self.redis, max_size=3)
+        self.assertTrue((yield from queue.empty()))
+        self.assertFalse((yield from queue.get_nowait()))
+        self.assertTrue((yield from queue.put(uuid.uuid4().bytes)))
+        self.assertTrue((yield from queue.put(uuid.uuid4().bytes)))
+        self.assertFalse((yield from queue.full()))
+        self.assertTrue((yield from queue.put(uuid.uuid4().bytes)))
+        self.assertEqual((yield from queue.qsize()), 3)
+        self.assertTrue((yield from queue.full()))
+        self.assertFalse((yield from queue.put(uuid.uuid4().bytes)))
+        self.assertEqual((yield from queue.qsize()), 3)
+        self.assertTrue((yield from queue.full()))
+
+    @run_until_complete
+    def test_blocking_timeout(self):
+        timeout = 1
+        queue = Queue(connection=self.redis, timeout=timeout)
+        query_start = time.time()
+        self.assertTrue((yield from queue.empty()))
+        # test default timeout
+        data = yield from queue.get()
+        self.assertFalse(data)
+        self.assertGreaterEqual(time.time() - query_start, timeout)
+        # test explicit timeout
+        query_start = time.time()
+        data = yield from queue.get(timeout=timeout)
+        self.assertFalse(data)
+        self.assertGreaterEqual(time.time() - query_start, timeout)
+


### PR DESCRIPTION
## What these changes does?
* Add Queue class that wraps around LPOP, BLPOP, RPUSH, LLEN

## How to test your changes?
[https://github.com/shicky/aioredis/blob/redis_queue/tests/queue_test.py](https://github.com/shicky/aioredis/blob/redis_queue/tests/queue_test.py)

## Related issue number
#123 

## Checklist

- [ O ] Code is written and well
- [ O ] Tests for the changes are provided
- [ X ] Documentation reflects the changes