### PR TITLE
Close RedisPool when connection to the redis server has failed (To prevent asyncio lock)

### DIFF
--- a/aioredis/pool.py
+++ b/aioredis/pool.py
@@ -29,7 +29,12 @@ def create_pool(address, *, db=0, password=None, ssl=None, encoding=None,
                      minsize=minsize, maxsize=maxsize,
                      commands_factory=commands_factory,
                      ssl=ssl, loop=loop)
-    yield from pool._fill_free(override_min=False)
+    try:
+        yield from pool._fill_free(override_min=False)
+    except Exception as ex:
+        pool.close()
+        raise
+
     return pool
 
 

--- a/aioredis/pool.py
+++ b/aioredis/pool.py
@@ -116,6 +116,7 @@ class RedisPool:
                 conn.close()
                 waiters.append(conn.wait_closed())
             yield from asyncio.gather(*waiters, loop=self._loop)
+            logger.debug("Closed %d connections", len(waiters))
 
     def close(self):
         """Close all free and in-progress connections and mark pool as closed.

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -391,8 +391,6 @@ def test_pool_close__used(create_pool, server, loop):
 
 @pytest.mark.run_loop
 def test_pool_check_closed_when_exception(create_pool, server, loop):
-    exception = False
-
     class TrackExceptionRecord(logging.Handler):
         def __init__(self):
             logging.Handler.__init__(self)
@@ -407,12 +405,8 @@ def test_pool_check_closed_when_exception(create_pool, server, loop):
     logger.setLevel(logging.DEBUG)
     logger.addHandler(handler)
 
-    try:
+    with pytest.raises(Exception):
         yield from create_pool(address=('127.3.2.1', 9999), loop=loop)
-    except:
-        exception = True
-
-    assert exception is True
 
     yield from asyncio.sleep(0, result=None, loop=loop)
     assert handler.has_closed_msg is True

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -1,5 +1,7 @@
 import asyncio
+import logging
 import pytest
+import re
 
 from aioredis import (
     RedisPool,
@@ -385,3 +387,43 @@ def test_pool_close__used(create_pool, server, loop):
 
         with pytest.raises(ConnectionClosedError):
             yield from redis.ping()
+
+
+@pytest.mark.run_loop
+def test_pool_check_closed_when_exception(create_pool, server, loop):
+    exception = False
+
+    class TrackExceptionRecord(logging.Handler):
+        def __init__(self):
+            logging.Handler.__init__(self)
+            self.has_closed_msg = False
+
+        def shouldFlush(self, record):
+            return True
+
+        def emit(self, record):
+            if re.match("Closed [0-9]+ connections", record.getMessage()):
+                self.has_closed_msg = True
+
+        def flush(self):
+            pass
+
+        def close(self):
+            pass
+
+    handler = TrackExceptionRecord()
+    logger = logging.getLogger('aioredis')
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+
+    try:
+        yield from create_pool(address=('127.3.2.1', 9999), loop=loop)
+    except:
+        exception = True
+
+    assert exception is True
+
+    yield from asyncio.sleep(0, result=None, loop=loop)
+    assert handler.has_closed_msg is True
+
+    logger.removeHandler(handler)

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -398,18 +398,9 @@ def test_pool_check_closed_when_exception(create_pool, server, loop):
             logging.Handler.__init__(self)
             self.has_closed_msg = False
 
-        def shouldFlush(self, record):
-            return True
-
         def emit(self, record):
             if re.match("Closed [0-9]+ connections", record.getMessage()):
                 self.has_closed_msg = True
-
-        def flush(self):
-            pass
-
-        def close(self):
-            pass
 
     handler = TrackExceptionRecord()
     logger = logging.getLogger('aioredis')


### PR DESCRIPTION
This patch closes the RedisPool when the connection to the redis server has failed. We would get an asyncio error when closing the event loop:

```
Task was destroyed but it is pending!
task: <Task pending coro=<RedisPool._do_close() running at python3.5/site-packages/aioredis/pool.py:102> wait_for=<Future pending cb=[Task._wakeup()]>>
```