### PR TITLE
Set default and validate section for info cmd

### DIFF
--- a/aioredis/commands/server.py
+++ b/aioredis/commands/server.py
@@ -12,6 +12,19 @@ class ServerCommandsMixin:
 
     SHUTDOWN_SAVE = 'SHUTDOWN_SAVE'
     SHUTDOWN_NOSAVE = 'SHUTDOWN_NOSAVE'
+    INFO_SECTIONS = [
+        'server',
+        'clients',
+        'memory',
+        'persistence',
+        'stats',
+        'replication',
+        'cpu',
+        'commandstats',
+        'cluster',
+        'keyspace',
+    ]
+    INFO_ARGS = INFO_SECTIONS + ['default', 'all']
 
     def bgrewriteaof(self):
         """Asynchronously rewrite the append-only file."""
@@ -112,9 +125,21 @@ class ServerCommandsMixin:
         fut = self._conn.execute('FLUSHDB')
         return wait_ok(fut)
 
-    def info(self, section):
-        """Get information and statistics about the server."""
-        # TODO: check section
+    def info(self, section='default'):
+        """Get information and statistics about the server.
+
+        If called without argument will return default set of sections.
+        For available sections, see http://redis.io/commands/INFO
+
+        :raises TypeError: if section is not string
+        :raises ValueError: if section is invalid
+
+        """
+        if not isinstance(section, str):
+            raise TypeError("section must be str")
+        section = section.lower()
+        if section not in self.INFO_ARGS:
+            raise ValueError("invalid section")
         fut = self._conn.execute(b'INFO', section, encoding='utf-8')
         return wait_convert(fut, parse_info)
 

--- a/aioredis/commands/server.py
+++ b/aioredis/commands/server.py
@@ -12,19 +12,6 @@ class ServerCommandsMixin:
 
     SHUTDOWN_SAVE = 'SHUTDOWN_SAVE'
     SHUTDOWN_NOSAVE = 'SHUTDOWN_NOSAVE'
-    INFO_SECTIONS = [
-        'server',
-        'clients',
-        'memory',
-        'persistence',
-        'stats',
-        'replication',
-        'cpu',
-        'commandstats',
-        'cluster',
-        'keyspace',
-    ]
-    INFO_ARGS = INFO_SECTIONS + ['default', 'all']
 
     def bgrewriteaof(self):
         """Asynchronously rewrite the append-only file."""
@@ -131,14 +118,10 @@ class ServerCommandsMixin:
         If called without argument will return default set of sections.
         For available sections, see http://redis.io/commands/INFO
 
-        :raises TypeError: if section is not string
         :raises ValueError: if section is invalid
 
         """
-        if not isinstance(section, str):
-            raise TypeError("section must be str")
-        section = section.lower()
-        if section not in self.INFO_ARGS:
+        if not section:
             raise ValueError("invalid section")
         fut = self._conn.execute(b'INFO', section, encoding='utf-8')
         return wait_convert(fut, parse_info)

--- a/tests/server_commands_test.py
+++ b/tests/server_commands_test.py
@@ -3,7 +3,6 @@ import pytest
 from unittest import mock
 
 from aioredis import ReplyError
-from aioredis.commands.server import ServerCommandsMixin
 
 
 @pytest.mark.run_loop
@@ -163,20 +162,8 @@ def test_info(redis):
     res = yield from redis.info('all')
     assert isinstance(res, dict)
 
-    with pytest.raises(TypeError):
-        yield from redis.info(1)
-
     with pytest.raises(ValueError):
         yield from redis.info('')
-
-
-@pytest.mark.run_loop
-@pytest.mark.parametrize('section', ServerCommandsMixin.INFO_SECTIONS)
-@pytest.redis_version(3, 0, 0, reason='cluster section exists since redis>=3')
-def test_info_sections(section, redis):
-    res = yield from redis.info(section)
-    assert isinstance(res, dict)
-    assert list(res.keys()) == [section]
 
 
 @pytest.mark.run_loop

--- a/tests/server_commands_test.py
+++ b/tests/server_commands_test.py
@@ -3,6 +3,7 @@ import pytest
 from unittest import mock
 
 from aioredis import ReplyError
+from aioredis.commands.server import ServerCommandsMixin
 
 
 @pytest.mark.run_loop
@@ -155,9 +156,27 @@ def test_dbsize(redis):
 
 
 @pytest.mark.run_loop
-@pytest.mark.skip("Not implemented")
-def test_info():
-    pass
+def test_info(redis):
+    res = yield from redis.info()
+    assert isinstance(res, dict)
+
+    res = yield from redis.info('all')
+    assert isinstance(res, dict)
+
+    with pytest.raises(TypeError):
+        yield from redis.info(1)
+
+    with pytest.raises(ValueError):
+        yield from redis.info('')
+
+
+@pytest.mark.run_loop
+@pytest.mark.parametrize('section', ServerCommandsMixin.INFO_SECTIONS)
+@pytest.redis_version(3, 0, 0, reason='cluster section exists since redis>=3')
+def test_info_sections(section, redis):
+    res = yield from redis.info(section)
+    assert isinstance(res, dict)
+    assert list(res.keys()) == [section]
 
 
 @pytest.mark.run_loop


### PR DESCRIPTION
Set a default param value of `'default'` (same as how redis-cli works http://redis.io/commands/INFO) for the `info()` command. Also added validation for the section param of the same command.