### PR TITLE
Avoid deprecation warnings due to legacy __aiter__ protocol.

### DIFF
--- a/aioredis/pubsub.py
+++ b/aioredis/pubsub.py
@@ -4,7 +4,7 @@ import sys
 import types
 
 from .abc import AbcChannel
-from .util import create_future, _converters
+from .util import create_future, _converters, correct_aiter
 from .errors import ChannelClosedError
 from .log import logger
 
@@ -15,7 +15,6 @@ __all__ = [
 ]
 
 PY_35 = sys.version_info >= (3, 5)
-PY_352 = sys.version_info >= (3, 5, 2)
 
 
 # End of pubsub messages stream marker.
@@ -166,13 +165,9 @@ if PY_35:
             self._args = args
             self._kw = kw
 
-        if PY_352:
-            def __aiter__(self):
-                return self
-        else:
-            @asyncio.coroutine
-            def __aiter__(self):
-                return self
+        @correct_aiter
+        def __aiter__(self):
+            return self
 
         @asyncio.coroutine
         def __anext__(self):

--- a/aioredis/pubsub.py
+++ b/aioredis/pubsub.py
@@ -15,6 +15,7 @@ __all__ = [
 ]
 
 PY_35 = sys.version_info >= (3, 5)
+PY_352 = sys.version_info >= (3, 5, 2)
 
 
 # End of pubsub messages stream marker.
@@ -165,9 +166,13 @@ if PY_35:
             self._args = args
             self._kw = kw
 
-        @asyncio.coroutine
-        def __aiter__(self):
-            return self
+        if PY_352:
+            def __aiter__(self):
+                return self
+        else:
+            @asyncio.coroutine
+            def __aiter__(self):
+                return self
 
         @asyncio.coroutine
         def __anext__(self):

--- a/aioredis/util.py
+++ b/aioredis/util.py
@@ -7,9 +7,15 @@ from .log import logger
 
 
 PY_35 = sys.version_info >= (3, 5)
-PY_352 = sys.version_info >= (3, 5, 2)
 
 _NOTSET = object()
+
+
+def correct_aiter(func):
+    if sys.version_info >= (3, 5, 2):
+        return func
+    else:
+        return asyncio.coroutine(func)
 
 
 # NOTE: never put here anything else;
@@ -104,13 +110,9 @@ if PY_35:
             self._cur = b'0'
             self._ret = []
 
-        if PY_352:
-            def __aiter__(self):
-                return self
-        else:
-            @asyncio.coroutine
-            def __aiter__(self):
-                return self
+        @correct_aiter
+        def __aiter__(self):
+            return self
 
     class _ScanIter(_BaseScanIter):
 

--- a/aioredis/util.py
+++ b/aioredis/util.py
@@ -7,6 +7,7 @@ from .log import logger
 
 
 PY_35 = sys.version_info >= (3, 5)
+PY_352 = sys.version_info >= (3, 5, 2)
 
 _NOTSET = object()
 
@@ -103,9 +104,13 @@ if PY_35:
             self._cur = b'0'
             self._ret = []
 
-        @asyncio.coroutine
-        def __aiter__(self):
-            return self
+        if PY_352:
+            def __aiter__(self):
+                return self
+        else:
+            @asyncio.coroutine
+            def __aiter__(self):
+                return self
 
     class _ScanIter(_BaseScanIter):
 


### PR DESCRIPTION
Starting with Python 3.5.2 the coroutine `__aiter__` functions will throw PendingDeprecationWarnings. Starting with Python 3.6 it will be actual DeprecationWarnings.

See https://www.python.org/dev/peps/pep-0492/#api-design-and-implementation-revisions