### PR TITLE
backward compatability with `yield from as conn`

### DIFF
--- a/aioredis/commands/__init__.py
+++ b/aioredis/commands/__init__.py
@@ -119,6 +119,16 @@ class Redis(GenericCommandsMixin, StringCommandsMixin,
         """
         return self._pool_or_conn.select(db)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def __iter__(self):
+        return self
+        yield
+
 
 @asyncio.coroutine
 def create_redis(address, *, db=None, password=None, ssl=None,

--- a/tests/connection_test.py
+++ b/tests/connection_test.py
@@ -448,3 +448,11 @@ def test_multi_exec__enc(create_connection, loop, server):
     assert queued == 'QUEUED'
     res = yield from conn.execute("DISCARD")
     assert res == 'OK'
+
+
+@pytest.mark.run_loop
+def test_yield_from_backwards_compatability(create_redis, server, loop):
+    pool = yield from create_redis(server.tcp_address, loop=loop)
+
+    with (yield from pool) as conn:
+        conn.ping()


### PR DESCRIPTION
https://github.com/aio-libs/aiohttp-session/blob/fe21ec8a68e8b1030dade1a363f9c0da6495ad1c/aiohttp_session/redis_storage.py#L28