### PR TITLE
Add asyncio trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ classifiers = [
     'Intended Audience :: Developers',
     'Topic :: Software Development',
     'Topic :: Software Development :: Libraries',
+    'Framework :: AsyncIO',
 ]
 
 setup(name='aioredis',


### PR DESCRIPTION
The `Framework :: AsyncIO` [trove classifier](https://pypi.python.org/pypi?%3Aaction=list_classifiers) has recently been added to PyPI. It can help people discover asyncio related packages.