### PR TITLE
Do not return a connection with pending requests to the pool

### DIFF
--- a/aioredis/pool.py
+++ b/aioredis/pool.py
@@ -340,6 +340,10 @@ class ConnectionsPool(AbcPool):
                 logger.warning(
                     "Connection %r is in subscribe mode, closing it.", conn)
                 conn.close()
+            elif conn._waiters:
+                logger.warning(
+                    "Connection %r has pending commands, closing it.", conn)
+                conn.close()
             elif conn.db == self.db:
                 if self.maxsize and self.freesize < self.maxsize:
                     self._pool.append(conn)

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -161,7 +161,7 @@ def test_release_pending(create_pool, loop, server):
 
     with (yield from pool) as conn:
         try:
-            yield from asyncio.wait_for(conn.brpop('somekey:not:exists'), 0.1)
+            yield from asyncio.wait_for(conn.execute(b'brpop', b'somekey:not:exists'), 0.1)
         except asyncio.TimeoutError:
             pass
     assert pool.size == 0

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -150,7 +150,7 @@ def test_release_closed(create_pool, loop, server):
     assert pool.size == 0
     assert pool.freesize == 0
 
-    
+
 @pytest.mark.run_loop
 def test_release_pending(create_pool, loop, server):
     pool = yield from create_pool(
@@ -161,7 +161,13 @@ def test_release_pending(create_pool, loop, server):
 
     with (yield from pool) as conn:
         try:
-            yield from asyncio.wait_for(conn.execute(b'blpop', b'somekey:not:exists', b'0'), 0.1, loop=loop)
+            yield from asyncio.wait_for(
+                conn.execute(
+                    b'blpop',
+                    b'somekey:not:exists',
+                    b'0'),
+                0.1,
+                loop=loop)
         except asyncio.TimeoutError:
             pass
     assert pool.size == 0

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -161,7 +161,7 @@ def test_release_pending(create_pool, loop, server):
 
     with (yield from pool) as conn:
         try:
-            yield from asyncio.wait_for(conn.execute(b'brpop', b'somekey:not:exists'), 0.1)
+            yield from asyncio.wait_for(conn.execute(b'brpop', b'somekey:not:exists'), 0.1, loop=loop)
         except asyncio.TimeoutError:
             pass
     assert pool.size == 0

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -161,7 +161,7 @@ def test_release_pending(create_pool, loop, server):
 
     with (yield from pool) as conn:
         try:
-            yield from asyncio.wait_for(conn.execute(b'brpop', b'somekey:not:exists'), 0.1, loop=loop)
+            yield from asyncio.wait_for(conn.execute(b'blpop', b'somekey:not:exists', b'0'), 0.1, loop=loop)
         except asyncio.TimeoutError:
             pass
     assert pool.size == 0

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -150,6 +150,23 @@ def test_release_closed(create_pool, loop, server):
     assert pool.size == 0
     assert pool.freesize == 0
 
+    
+@pytest.mark.run_loop
+def test_release_pending(create_pool, loop, server):
+    pool = yield from create_pool(
+        server.tcp_address,
+        minsize=1, loop=loop)
+    assert pool.size == 1
+    assert pool.freesize == 1
+
+    with (yield from pool) as conn:
+        try:
+            yield from asyncio.wait_for(conn.brpop('somekey:not:exists'), 0.1)
+        except asyncio.TimeoutError:
+            pass
+    assert pool.size == 0
+    assert pool.freesize == 0
+
 
 @pytest.mark.run_loop
 def test_release_bad_connection(create_pool, create_redis, loop, server):


### PR DESCRIPTION
A redis connection cannot return to a pool if it has pending requests, especially blocking commands like "BLPOP/BRPOP". The command may block for an indefinite time, and stops the following commands from executing if the connection is acquired from the pool. Also, because the command is still executing, the BRPOP command may pop an item and drop it which creates bugs which are very hard to debug.