### PR TITLE
Pub/Sub Receiver stop() fix

### DIFF
--- a/tests/pubsub_receiver_test.py
+++ b/tests/pubsub_receiver_test.py
@@ -181,13 +181,15 @@ def test_stopped(create_connection, server, loop):
         yield from asyncio.sleep(0, loop=loop)
 
     assert len(cm.output) == 1
+    # Receiver must have 1 EndOfStream message
     warn_messaege = (
         "WARNING:aioredis:Pub/Sub listener message after stop: "
-        "<_Sender name:b'channel:1', is_pattern:False, receiver:"
-        "<Receiver is_active:False, senders:1, qsize:0>>, b'Hello'"
+        "sender: <_Sender name:b'channel:1', is_pattern:False, receiver:"
+        "<Receiver is_active:True, senders:1, qsize:1>>, data: b'Hello'"
     )
     assert cm.output == [warn_messaege]
 
+    assert (yield from mpsc.get()) is None
     with pytest.raises(ChannelClosedError):
         yield from mpsc.get()
     res = yield from mpsc.wait_message()

--- a/tests/py35_pubsub_receiver_test.py
+++ b/tests/py35_pubsub_receiver_test.py
@@ -22,14 +22,36 @@ async def test_pubsub_receiver_iter(create_redis, server, loop):
     snd2, = await sub.subscribe(mpsc.channel('chan:2'))
     snd3, = await sub.psubscribe(mpsc.pattern('chan:*'))
 
-    await pub.publish_json('chan:1', {'Hello': 'World'})
-    await pub.publish_json('chan:2', ['message'])
-    mpsc.stop()
-    await asyncio.sleep(0, loop=loop)
+    subscribers = await pub.publish_json('chan:1', {'Hello': 'World'})
+    assert subscribers > 1
+    subscribers = await pub.publish_json('chan:2', ['message'])
+    assert subscribers > 1
+    loop.call_later(0, mpsc.stop)
+    # await asyncio.sleep(0, loop=loop)
     assert await tsk == [
         (snd1, b'{"Hello": "World"}'),
         (snd3, (b'chan:1', b'{"Hello": "World"}')),
         (snd2, b'["message"]'),
         (snd3, (b'chan:2', b'["message"]')),
         ]
+    assert not mpsc.is_active
+
+
+@pytest.mark.run_loop(timeout=5)
+async def test_pubsub_receiver_call_stop_with_empty_queue(
+        create_redis, server, loop):
+    sub = await create_redis(server.tcp_address, loop=loop)
+    pub = await create_redis(server.tcp_address, loop=loop)
+
+    mpsc = Receiver(loop=loop)
+
+    # FIXME: currently at least one subscriber is needed
+    snd1, = await sub.subscribe(mpsc.channel('chan:1'))
+
+    now = loop.time()
+    loop.call_later(.5, mpsc.stop)
+    async for _ in mpsc.iter():
+        assert False, "StopAsyncIteration not raised"
+    dt = loop.time() - now
+    assert dt <= 1.5
     assert not mpsc.is_active

--- a/tests/py35_pubsub_receiver_test.py
+++ b/tests/py35_pubsub_receiver_test.py
@@ -41,7 +41,6 @@ async def test_pubsub_receiver_iter(create_redis, server, loop):
 async def test_pubsub_receiver_call_stop_with_empty_queue(
         create_redis, server, loop):
     sub = await create_redis(server.tcp_address, loop=loop)
-    pub = await create_redis(server.tcp_address, loop=loop)
 
     mpsc = Receiver(loop=loop)
 
@@ -50,7 +49,7 @@ async def test_pubsub_receiver_call_stop_with_empty_queue(
 
     now = loop.time()
     loop.call_later(.5, mpsc.stop)
-    async for _ in mpsc.iter():
+    async for i in mpsc.iter():  # noqa (flake8 bug with async for)
         assert False, "StopAsyncIteration not raised"
     dt = loop.time() - now
     assert dt <= 1.5


### PR DESCRIPTION
This fixes the case when pubsub receiver is blocked in `get()` and then `stop()` is called,
see test for details.