### PR TITLE
Support for connection timeout param

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -22,3 +22,4 @@ Ihor Gorobets
 Thanos Lefteris
 Ilya Goncharov
 Brett Rosen
+Pau Freixes

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -72,9 +72,13 @@ def create_connection(address, *, db=None, password=None, ssl=None,
     """
     assert isinstance(address, (tuple, list, str)), "tuple or str expected"
 
+    if timeout is not None and timeout <= 0:
+        raise ValueError("Timeout has to be None or a number greater than 0")
+
     if isinstance(address, (list, tuple)):
         host, port = address
         logger.debug("Creating tcp connection to %r", address)
+        print(asyncio.open_connection)
         reader, writer = yield from asyncio.wait_for(asyncio.open_connection(
             host, port, ssl=ssl, loop=loop), timeout, loop=loop)
         sock = writer.transport.get_extra_info('socket')

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -78,7 +78,6 @@ def create_connection(address, *, db=None, password=None, ssl=None,
     if isinstance(address, (list, tuple)):
         host, port = address
         logger.debug("Creating tcp connection to %r", address)
-        print(asyncio.open_connection)
         reader, writer = yield from asyncio.wait_for(asyncio.open_connection(
             host, port, ssl=ssl, loop=loop), timeout, loop=loop)
         sock = writer.transport.get_extra_info('socket')

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -43,7 +43,7 @@ _PUBSUB_COMMANDS = (
 
 @asyncio.coroutine
 def create_connection(address, *, db=None, password=None, ssl=None,
-                      encoding=None, parser=None, loop=None):
+                      encoding=None, parser=None, loop=None, timeout=None):
     """Creates redis connection.
 
     Opens connection to Redis server specified by address argument.
@@ -54,6 +54,10 @@ def create_connection(address, *, db=None, password=None, ssl=None,
 
     SSL argument is passed through to asyncio.create_connection.
     By default SSL/TLS is not used.
+
+    By default any timeout is applied at the connection stage, however
+    you can set a limitted time used trying to open a connection via
+    the `timeout` Kw.
 
     Encoding argument can be used to decode byte-replies to strings.
     By default no decoding is done.
@@ -71,8 +75,8 @@ def create_connection(address, *, db=None, password=None, ssl=None,
     if isinstance(address, (list, tuple)):
         host, port = address
         logger.debug("Creating tcp connection to %r", address)
-        reader, writer = yield from asyncio.open_connection(
-            host, port, ssl=ssl, loop=loop)
+        reader, writer = yield from asyncio.wait_for(asyncio.open_connection(
+            host, port, ssl=ssl, loop=loop), timeout, loop=loop)
         sock = writer.transport.get_extra_info('socket')
         if sock is not None:
             sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
@@ -80,8 +84,9 @@ def create_connection(address, *, db=None, password=None, ssl=None,
         address = tuple(address[:2])
     else:
         logger.debug("Creating unix connection to %r", address)
-        reader, writer = yield from asyncio.open_unix_connection(
-            address, ssl=ssl, loop=loop)
+        reader, writer = yield from asyncio.wait_for(
+            asyncio.open_unix_connection(address, ssl=ssl, loop=loop),
+            timeout, loop=loop)
         sock = writer.transport.get_extra_info('socket')
         if sock is not None:
             address = sock.getpeername()

--- a/aioredis/pool.py
+++ b/aioredis/pool.py
@@ -17,7 +17,7 @@ PY_35 = sys.version_info >= (3, 5)
 @asyncio.coroutine
 def create_pool(address, *, db=None, password=None, ssl=None, encoding=None,
                 minsize=1, maxsize=10, commands_factory=_NOTSET,
-                parser=None, loop=None):
+                parser=None, loop=None, timeout_create_connection=None):
     # FIXME: rewrite docstring
     """Creates Redis Pool.
 
@@ -38,7 +38,9 @@ def create_pool(address, *, db=None, password=None, ssl=None, encoding=None,
 
     pool = ConnectionsPool(address, db, password, encoding,
                            minsize=minsize, maxsize=maxsize,
-                           ssl=ssl, parser=parser, loop=loop)
+                           ssl=ssl, parser=parser,
+                           timeout_create_connection=timeout_create_connection,
+                           loop=loop)
     try:
         yield from pool._fill_free(override_min=False)
     except Exception as ex:
@@ -52,7 +54,8 @@ class ConnectionsPool(AbcPool):
     """Redis connections pool."""
 
     def __init__(self, address, db=None, password=None, encoding=None,
-                 *, minsize, maxsize, ssl=None, parser=None, loop=None):
+                 *, minsize, maxsize, ssl=None, parser=None,
+                 timeout_create_connection=None, loop=None):
         assert isinstance(minsize, int) and minsize >= 0, (
             "minsize must be int >= 0", minsize, type(minsize))
         assert maxsize is not None, "Arbitrary pool size is disallowed."
@@ -69,6 +72,7 @@ class ConnectionsPool(AbcPool):
         self._encoding = encoding
         self._parser_class = parser
         self._minsize = minsize
+        self._timeout_create_connection = timeout_create_connection
         self._loop = loop
         self._pool = collections.deque(maxlen=maxsize)
         self._used = set()
@@ -392,6 +396,7 @@ class ConnectionsPool(AbcPool):
                     # connection may be closed at yield point
                     self._drop_closed()
 
+    @asyncio.coroutine
     def _create_new_connection(self, address):
         return create_connection(address,
                                  db=self._db,
@@ -399,6 +404,7 @@ class ConnectionsPool(AbcPool):
                                  ssl=self._ssl,
                                  encoding=self._encoding,
                                  parser=self._parser_class,
+                                 timeout=self._timeout_create_connection,
                                  loop=self._loop)
 
     @asyncio.coroutine

--- a/aioredis/pool.py
+++ b/aioredis/pool.py
@@ -17,7 +17,7 @@ PY_35 = sys.version_info >= (3, 5)
 @asyncio.coroutine
 def create_pool(address, *, db=None, password=None, ssl=None, encoding=None,
                 minsize=1, maxsize=10, commands_factory=_NOTSET,
-                parser=None, loop=None, timeout_create_connection=None):
+                parser=None, loop=None, create_connection_timeout=None):
     # FIXME: rewrite docstring
     """Creates Redis Pool.
 
@@ -39,7 +39,7 @@ def create_pool(address, *, db=None, password=None, ssl=None, encoding=None,
     pool = ConnectionsPool(address, db, password, encoding,
                            minsize=minsize, maxsize=maxsize,
                            ssl=ssl, parser=parser,
-                           timeout_create_connection=timeout_create_connection,
+                           create_connection_timeout=create_connection_timeout,
                            loop=loop)
     try:
         yield from pool._fill_free(override_min=False)
@@ -55,7 +55,7 @@ class ConnectionsPool(AbcPool):
 
     def __init__(self, address, db=None, password=None, encoding=None,
                  *, minsize, maxsize, ssl=None, parser=None,
-                 timeout_create_connection=None, loop=None):
+                 create_connection_timeout=None, loop=None):
         assert isinstance(minsize, int) and minsize >= 0, (
             "minsize must be int >= 0", minsize, type(minsize))
         assert maxsize is not None, "Arbitrary pool size is disallowed."
@@ -72,7 +72,7 @@ class ConnectionsPool(AbcPool):
         self._encoding = encoding
         self._parser_class = parser
         self._minsize = minsize
-        self._timeout_create_connection = timeout_create_connection
+        self._create_connection_timeout = create_connection_timeout
         self._loop = loop
         self._pool = collections.deque(maxlen=maxsize)
         self._used = set()
@@ -396,7 +396,6 @@ class ConnectionsPool(AbcPool):
                     # connection may be closed at yield point
                     self._drop_closed()
 
-    @asyncio.coroutine
     def _create_new_connection(self, address):
         return create_connection(address,
                                  db=self._db,
@@ -404,7 +403,7 @@ class ConnectionsPool(AbcPool):
                                  ssl=self._ssl,
                                  encoding=self._encoding,
                                  parser=self._parser_class,
-                                 timeout=self._timeout_create_connection,
+                                 timeout=self._create_connection_timeout,
                                  loop=self._loop)
 
     @asyncio.coroutine

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -36,12 +36,15 @@ Connection usage is as simple as:
 
 
 .. cofunction:: create_connection(address, \*, db=0, password=None, ssl=None,\
-                                  encoding=None, parser=None, loop=None)
+                                  encoding=None, parser=None, loop=None, timeout=None)
 
    Creates Redis connection.
 
    .. versionchanged:: v1.0
       ``parser`` argument added.
+
+   .. versionchanged:: v0.3.1
+      ``timeout`` argument added.
 
    :param address: An address where to connect. Can be a (host, port) tuple or
                    unix domain socket path string.
@@ -67,6 +70,11 @@ Connection usage is as simple as:
    :param loop: An optional *event loop* instance
                 (uses :func:`asyncio.get_event_loop` if not specified).
    :type loop: :ref:`EventLoop<asyncio-event-loop>`
+
+   :param timeout: Max time used to open a connection, otherwise
+                   raise `asyncio.TimeoutError` exception.
+                   ``None`` by default
+   :type timeout: float or None
 
    :return: :class:`RedisConnection` instance.
 
@@ -246,6 +254,9 @@ The library provides connections pool. The basic usage is as follows:
    .. deprecated:: v0.2.9
       *commands_factory* argument is deprecated and will be removed in *v0.3*.
 
+   .. versionchanged:: v0.3.1
+      ``timeout_create_connection`` argument added.
+
    .. versionchanged:: v1.0
       ``parser`` argument added.
 
@@ -285,6 +296,11 @@ The library provides connections pool. The basic usage is as follows:
    :param loop: An optional *event loop* instance
                 (uses :func:`asyncio.get_event_loop` if not specified).
    :type loop: :ref:`EventLoop<asyncio-event-loop>`
+
+   :param timeout_create_connection: Max time used to open a connection,
+                                     otherwise raise an `asyncio.TimeoutError`.
+                                     ``None`` by default.
+   :type timeout_create_connection: float or None
 
    :return: :class:`ConnectionsPool` instance.
 

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -74,7 +74,7 @@ Connection usage is as simple as:
    :param timeout: Max time used to open a connection, otherwise
                    raise `asyncio.TimeoutError` exception.
                    ``None`` by default
-   :type timeout: float or None
+   :type timeout: float greater than 0 or None
 
    :return: :class:`RedisConnection` instance.
 
@@ -255,7 +255,7 @@ The library provides connections pool. The basic usage is as follows:
       *commands_factory* argument is deprecated and will be removed in *v0.3*.
 
    .. versionchanged:: v0.3.1
-      ``timeout_create_connection`` argument added.
+      ``create_connection_timeout`` argument added.
 
    .. versionchanged:: v1.0
       ``parser`` argument added.
@@ -297,10 +297,10 @@ The library provides connections pool. The basic usage is as follows:
                 (uses :func:`asyncio.get_event_loop` if not specified).
    :type loop: :ref:`EventLoop<asyncio-event-loop>`
 
-   :param timeout_create_connection: Max time used to open a connection,
+   :param create_connection_timeout: Max time used to open a connection,
                                      otherwise raise an `asyncio.TimeoutError`.
                                      ``None`` by default.
-   :type timeout_create_connection: float or None
+   :type create_connection_timeout: float greater than 0 or None
 
    :return: :class:`ConnectionsPool` instance.
 

--- a/tests/connection_test.py
+++ b/tests/connection_test.py
@@ -33,6 +33,13 @@ def test_connect_tcp(request, create_connection, loop, server):
 
 
 @pytest.mark.run_loop
+def test_connect_tcp_timeout(request, create_connection, loop, server):
+    with pytest.raises(asyncio.TimeoutError):
+        yield from create_connection(
+            server.tcp_address, loop=loop, timeout=0)
+
+
+@pytest.mark.run_loop
 @pytest.mark.skipif(sys.platform == 'win32',
                     reason="No unixsocket on Windows")
 def test_connect_unixsocket(create_connection, loop, server):
@@ -41,6 +48,15 @@ def test_connect_unixsocket(create_connection, loop, server):
     assert conn.db == 0
     assert conn.address == server.unixsocket
     assert str(conn) == '<RedisConnection [db:0]>'
+
+
+@pytest.mark.run_loop
+@pytest.mark.skipif(sys.platform == 'win32',
+                    reason="No unixsocket on Windows")
+def test_connect_unixsocket_timeout(create_connection, loop, server):
+    with pytest.raises(asyncio.TimeoutError):
+        yield from create_connection(
+            server.unixsocket, db=0, loop=loop, timeout=0)
 
 
 def test_global_loop(create_connection, loop, server):

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -58,6 +58,14 @@ def test_maxsize(maxsize, create_pool, loop, server):
             minsize=2, maxsize=maxsize, loop=loop)
 
 
+@pytest.mark.run_loop
+def test_create_connection_timeout(create_pool, loop, server):
+    with pytest.raises(asyncio.TimeoutError):
+        yield from create_pool(
+            server.tcp_address, loop=loop,
+            timeout_create_connection=0)
+
+
 def test_no_yield_from(pool):
     with pytest.raises(RuntimeError):
         with pool:


### PR DESCRIPTION
Related to #184, it allows aioredis to configure a limited
time that will be used trying to open a connection if it is
reached an `asyncio.TimeoutError` will be raised

By default, any timeout is configured.

Not very happy with the current test implementation, at integration level there is not an easy way to test it, if you come with something better please ping me. 