### PR TITLE
Narrow the coverage to the aioredis package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ test:
 	$(PYTEST)
 
 cov coverage:
-	$(PYTEST) --cov
+	$(PYTEST) --cov=aioredis
 
 dist: clean man-doc
 	$(PYTHON) setup.py sdist bdist_wheel


### PR DESCRIPTION
Before this commit the coverage was missleading, gathering the code
of the test aside of the aioredis package.