### PR TITLE
Allow inject a pool class and connection class

### DIFF
--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -43,7 +43,8 @@ _PUBSUB_COMMANDS = (
 
 @asyncio.coroutine
 def create_connection(address, *, db=None, password=None, ssl=None,
-                      encoding=None, parser=None, loop=None, timeout=None):
+                      encoding=None, parser=None, loop=None, timeout=None,
+                      connection_cls=None):
     """Creates redis connection.
 
     Opens connection to Redis server specified by address argument.
@@ -66,7 +67,8 @@ def create_connection(address, *, db=None, password=None, ssl=None,
     By default hiredis.Reader is used (unless it is missing or platform
     is not CPython).
 
-    Return value is RedisConnection instance.
+    Return value is RedisConnection instance or a connection_cls if it is
+    given.
 
     This function is a coroutine.
     """
@@ -93,9 +95,11 @@ def create_connection(address, *, db=None, password=None, ssl=None,
         sock = writer.transport.get_extra_info('socket')
         if sock is not None:
             address = sock.getpeername()
-    conn = RedisConnection(reader, writer, encoding=encoding,
-                           address=address, parser=parser,
-                           loop=loop)
+
+    cls = connection_cls or RedisConnection
+    conn = cls(reader, writer, encoding=encoding,
+               address=address, parser=parser,
+               loop=loop)
 
     try:
         if password is not None:

--- a/aioredis/pool.py
+++ b/aioredis/pool.py
@@ -37,7 +37,13 @@ def create_pool(address, *, db=None, password=None, ssl=None, encoding=None,
             "commands_factory argument is deprecated and will be removed!",
             DeprecationWarning)
 
-    cls = pool_cls or ConnectionsPool
+    if pool_cls:
+        assert issubclass(pool_cls, AbcPool),\
+                "pool_class does not meet the AbcPool contract"
+        cls = pool_cls
+    else:
+        cls = ConnectionsPool
+
     pool = cls(address, db, password, encoding,
                minsize=minsize, maxsize=maxsize,
                ssl=ssl, parser=parser,

--- a/aioredis/pool.py
+++ b/aioredis/pool.py
@@ -17,7 +17,8 @@ PY_35 = sys.version_info >= (3, 5)
 @asyncio.coroutine
 def create_pool(address, *, db=None, password=None, ssl=None, encoding=None,
                 minsize=1, maxsize=10, commands_factory=_NOTSET,
-                parser=None, loop=None, create_connection_timeout=None):
+                parser=None, loop=None, create_connection_timeout=None,
+                pool_cls=None, connection_cls=None):
     # FIXME: rewrite docstring
     """Creates Redis Pool.
 
@@ -29,18 +30,20 @@ def create_pool(address, *, db=None, password=None, ssl=None, encoding=None,
 
     All arguments are the same as for create_connection.
 
-    Returns RedisPool instance.
+    Returns RedisPool instance or a pool_cls if it is given.
     """
     if commands_factory is not _NOTSET:
         warnings.warn(
             "commands_factory argument is deprecated and will be removed!",
             DeprecationWarning)
 
-    pool = ConnectionsPool(address, db, password, encoding,
-                           minsize=minsize, maxsize=maxsize,
-                           ssl=ssl, parser=parser,
-                           create_connection_timeout=create_connection_timeout,
-                           loop=loop)
+    cls = pool_cls or ConnectionsPool
+    pool = cls(address, db, password, encoding,
+               minsize=minsize, maxsize=maxsize,
+               ssl=ssl, parser=parser,
+               create_connection_timeout=create_connection_timeout,
+               connection_cls=connection_cls,
+               loop=loop)
     try:
         yield from pool._fill_free(override_min=False)
     except Exception as ex:
@@ -55,7 +58,9 @@ class ConnectionsPool(AbcPool):
 
     def __init__(self, address, db=None, password=None, encoding=None,
                  *, minsize, maxsize, ssl=None, parser=None,
-                 create_connection_timeout=None, loop=None):
+                 create_connection_timeout=None,
+                 connection_cls=None,
+                 loop=None):
         assert isinstance(minsize, int) and minsize >= 0, (
             "minsize must be int >= 0", minsize, type(minsize))
         assert maxsize is not None, "Arbitrary pool size is disallowed."
@@ -81,6 +86,7 @@ class ConnectionsPool(AbcPool):
         self._close_state = asyncio.Event(loop=loop)
         self._close_waiter = async_task(self._do_close(), loop=loop)
         self._pubsub_conn = None
+        self._connection_cls = connection_cls
 
     def __repr__(self):
         return '<{} [db:{}, size:[{}:{}], free:{}]>'.format(
@@ -404,6 +410,7 @@ class ConnectionsPool(AbcPool):
                                  encoding=self._encoding,
                                  parser=self._parser_class,
                                  timeout=self._create_connection_timeout,
+                                 connection_cls=self._connection_cls,
                                  loop=self._loop)
 
     @asyncio.coroutine

--- a/tests/connection_test.py
+++ b/tests/connection_test.py
@@ -9,6 +9,7 @@ from aioredis.util import async_task
 from aioredis import (
     ConnectionClosedError,
     ProtocolError,
+    RedisConnection,
     RedisError,
     ReplyError,
     Channel,
@@ -32,6 +33,18 @@ def test_connect_tcp(request, create_connection, loop, server):
     assert conn.address[0] in ('127.0.0.1', '::1')
     assert conn.address[1] == server.tcp_address.port
     assert str(conn) == '<RedisConnection [db:0]>'
+
+
+@pytest.mark.run_loop
+def test_connect_inject_connection_cls(request, create_connection, loop, server):
+
+    class MyConnection(RedisConnection):
+        pass
+
+    conn = yield from create_connection(
+        server.tcp_address, loop=loop, connection_cls=MyConnection)
+
+    assert isinstance(conn, MyConnection)
 
 
 @pytest.mark.run_loop

--- a/tests/connection_test.py
+++ b/tests/connection_test.py
@@ -36,7 +36,11 @@ def test_connect_tcp(request, create_connection, loop, server):
 
 
 @pytest.mark.run_loop
-def test_connect_inject_connection_cls(request, create_connection, loop, server):
+def test_connect_inject_connection_cls(
+        request,
+        create_connection,
+        loop,
+        server):
 
     class MyConnection(RedisConnection):
         pass

--- a/tests/connection_test.py
+++ b/tests/connection_test.py
@@ -52,6 +52,18 @@ def test_connect_inject_connection_cls(
 
 
 @pytest.mark.run_loop
+def test_connect_inject_connection_cls_invalid(
+        request,
+        create_connection,
+        loop,
+        server):
+
+    with pytest.raises(AssertionError):
+        yield from create_connection(
+            server.tcp_address, loop=loop, connection_cls=type)
+
+
+@pytest.mark.run_loop
 def test_connect_tcp_timeout(request, create_connection, loop, server):
     with patch('aioredis.connection.asyncio.open_connection') as\
             open_conn_mock:

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -9,6 +9,7 @@ from aioredis import (
     ReplyError,
     PoolClosedError,
     ConnectionClosedError,
+    ConnectionsPool
     )
 from aioredis.util import async_task
 
@@ -150,6 +151,20 @@ def test_create_no_minsize(create_pool, loop, server):
                                         loop=loop)
     assert pool.size == 1
     assert pool.freesize == 1
+
+
+@pytest.mark.run_loop
+def test_create_pool_cls(create_pool, loop, server):
+
+    class MyPool(ConnectionsPool):
+        pass
+
+    pool = yield from create_pool(
+        server.tcp_address,
+        loop=loop,
+        pool_cls=MyPool)
+
+    assert isinstance(pool, MyPool)
 
 
 @pytest.mark.run_loop

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -168,6 +168,15 @@ def test_create_pool_cls(create_pool, loop, server):
 
 
 @pytest.mark.run_loop
+def test_create_pool_cls_invalid(create_pool, loop, server):
+    with pytest.raises(AssertionError):
+        yield from create_pool(
+            server.tcp_address,
+            loop=loop,
+            pool_cls=type)
+
+
+@pytest.mark.run_loop
 def test_release_closed(create_pool, loop, server):
     pool = yield from create_pool(
         server.tcp_address,


### PR DESCRIPTION
Both factories to create a new pool and new connections allow to the
developer pass as a kw an alternative class. Developers can develop
their own pools or connection classes inheriting from the official one
and implementing ad-hoc functionalities.