### PR TITLE
Fix critical bug with patched Lock

### DIFF
--- a/aioredis/locks.py
+++ b/aioredis/locks.py
@@ -41,3 +41,4 @@ class Lock(_Lock):
         for fut in self._waiters:
             if not fut.done():
                 fut.set_result(True)
+                break


### PR DESCRIPTION
@popravich it should be merged ASAP, sorry fo the bug introduced plus no detection in the UT. I will do another MR to have support for Python 3.6.2, using the Python implementation.

We detected that issue together with @argaen when the new Python RC was tested with aiocache.

We have been running our system with that version since it was published, we didn't notice any particular issue. I guess that having a pool overallocated of opened connections has hide that mistake. 