### PR TITLE
update PyPy3 to nightly build (>v5.8.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 
 env:
   global:
-  - REDIS_TAGS="2.6.17 2.8.22 3.0.7 3.2.8 4.0-rc2" INSTALL_DIR=$HOME/redis PYPY_RELEASE="pypy3-v5.7.1-linux64"
+  - REDIS_TAGS="2.6.17 2.8.22 3.0.7 3.2.8 4.0-rc2" INSTALL_DIR=$HOME/redis PYPY_RELEASE="pypy-c-jit-91658-97ca3ac43c30-linux64"
 
 python:
 - "3.3"
@@ -41,7 +41,7 @@ install:
 - make -j ci-build-redis
 - |
     if [ "$TRAVIS_PYTHON_VERSION" = "pypy-5.3.1" ]; then
-      wget -nv -c "https://bitbucket.org/pypy/pypy/downloads/$PYPY_RELEASE.tar.bz2" -O - | tar -xjC $HOME
+      wget -nv -c "http://buildbot.pypy.org/nightly/py3.5/$PYPY_RELEASE.tar.bz2" -O - | tar -xjC $HOME
       export PYPY_VERSION="$($HOME/$PYPY_RELEASE/bin/pypy3 -V | grep PyPy | cut -d ' ' -f2)"
       $HOME/$PYPY_RELEASE/bin/pypy3 -m venv --clear $HOME/virtualenvs/pypy3
       $HOME/$PYPY_RELEASE/bin/pypy3 -m venv $HOME/virtualenvs/pypy3


### PR DESCRIPTION
v5.8.0 has a bug (related to C python extension, see  https://bitbucket.org/pypy/pypy/issues/2592/pypy3-listpop-returns-none-for-a-list), so update to v5.9.0 (ie, nightly build)