### PR TITLE
#186 Support for MaxClientsError for connection and pool

### DIFF
--- a/aioredis/__init__.py
+++ b/aioredis/__init__.py
@@ -16,6 +16,7 @@ from .errors import (
     ReadOnlyError,
     RedisError,
     ReplyError,
+    MaxClientsError,
     ChannelClosedError,
     WatchVariableError,
     PoolClosedError,
@@ -43,6 +44,7 @@ __all__ = [
     # Errors
     'RedisError',
     'ReplyError',
+    'MaxClientsError',
     'ProtocolError',
     'PipelineError',
     'MultiExecError',

--- a/aioredis/errors.py
+++ b/aioredis/errors.py
@@ -2,6 +2,7 @@ __all__ = [
     'RedisError',
     'ProtocolError',
     'ReplyError',
+    'MaxClientsError',
     'PipelineError',
     'MultiExecError',
     'WatchVariableError',
@@ -25,8 +26,25 @@ class ProtocolError(RedisError):
 class ReplyError(RedisError):
     """Raised for redis error replies (-ERR)."""
 
+    _REPLY = None
 
-class PipelineError(ReplyError):
+    def __new__(cls, *args):
+        msg, *_ = args
+        for c in cls.__subclasses__():
+            if msg == c._REPLY:
+                return c(*args)
+
+        return super().__new__(cls, *args)
+
+
+class MaxClientsError(ReplyError):
+    """Raised for redis server when the maximum number of client has been
+    reached."""
+
+    _REPLY = "ERR max number of clients reached"
+
+
+class PipelineError(RedisError):
     """Raised if command within pipeline raised error."""
 
     def __init__(self, errors):

--- a/aioredis/pool.py
+++ b/aioredis/pool.py
@@ -394,6 +394,9 @@ class ConnectionsPool(AbcPool):
             self._acquiring += 1
             try:
                 conn = yield from self._create_new_connection(address)
+                # check the healthy of that connection, if
+                # something went wrong just trigger the Exception
+                yield from conn.execute('ping')
                 self._pool.append(conn)
             finally:
                 self._acquiring -= 1

--- a/tests/connection_test.py
+++ b/tests/connection_test.py
@@ -107,6 +107,7 @@ def test_connect_unixsocket_timeout(create_connection, loop, server):
 
 
 @pytest.mark.run_loop
+@pytest.redis_version(2, 8, 0, reason="maxclients config setting")
 def test_connect_maxclients(request, create_connection, loop, start_server):
     server = start_server('server-maxclients')
     conn = yield from create_connection(

--- a/tests/connection_test.py
+++ b/tests/connection_test.py
@@ -13,6 +13,7 @@ from aioredis import (
     RedisError,
     ReplyError,
     Channel,
+    MaxClientsError
     )
 
 
@@ -103,6 +104,19 @@ def test_connect_unixsocket_timeout(create_connection, loop, server):
         with pytest.raises(asyncio.TimeoutError):
             yield from create_connection(
                 server.unixsocket, db=0, loop=loop, timeout=0.1)
+
+
+@pytest.mark.run_loop
+def test_connect_maxclients(request, create_connection, loop, start_server):
+    server = start_server('server-maxclients')
+    conn = yield from create_connection(
+        server.tcp_address, loop=loop)
+    yield from conn.execute(b'CONFIG', b'SET', 'maxclients', 1)
+
+    with pytest.raises(MaxClientsError):
+        conn2 = yield from create_connection(
+            server.tcp_address, loop=loop)
+        yield from conn2.execute('ping')
 
 
 def test_global_loop(create_connection, loop, server):

--- a/tests/errors_test.py
+++ b/tests/errors_test.py
@@ -1,0 +1,23 @@
+from aioredis.errors import ReplyError
+from aioredis.errors import MaxClientsError
+
+
+class TestReplyError:
+
+    def test_return_default_class(self):
+        assert isinstance(ReplyError(None), ReplyError)
+
+    def test_return_adhoc_class(self):
+        class MyError(ReplyError):
+            _REPLY = "my error"
+
+        assert isinstance(ReplyError("my error"), MyError)
+
+
+class TestMaxClientsError:
+
+    def test_return_max_clients_error(self):
+        assert isinstance(
+            ReplyError("ERR max number of clients reached"),
+            MaxClientsError
+        )

--- a/tests/transaction_commands_test.py
+++ b/tests/transaction_commands_test.py
@@ -87,7 +87,7 @@ def test_discard(redis):
     fut2 = tr.connection.execute('MULTI')
     fut3 = tr.connection.execute('incr', 'foo')
 
-    with pytest.raises(ReplyError):
+    with pytest.raises(MultiExecError):
         yield from tr.execute()
     with pytest.raises(TypeError):
         yield from fut1


### PR DESCRIPTION
When a new connection tries to get connected to the redis server and it
has been configured with a maximum number of connections, the client
will get a `MaxClientsError` exception if this limit is reached out.

Also if a pool initialization with a `min_size` that cant meet the
requirements - beucase of that limit u others issues - the pool creation
will return also a `MaxClientsError`.