### PR TITLE
Use a custom StreamrReader #271

### DIFF
--- a/aioredis/stream.py
+++ b/aioredis/stream.py
@@ -1,0 +1,62 @@
+import asyncio
+
+
+class StreamReader(asyncio.StreamReader):
+    """
+    Override the official StreamReader to address the
+    following issue: http://bugs.python.org/issue30861
+
+    Also it leverages to get rid of the dobule buffer and
+    get rid of one coroutine step. Data flows from the buffer
+    to the Redis parser directly.
+    """
+
+    def set_parser(self, parser):
+        self._parser = parser
+
+    def feed_data(self, data):
+        assert not self._eof, 'feed_data after feed_eof'
+
+        if not data:
+            return
+
+        self._parser.feed(data)
+        self._wakeup_waiter()
+
+        # TODO: implement pause the read. Its needed
+        #       expose the len of the buffer from hiredis
+        #       to make it possible.
+
+    @asyncio.coroutine
+    def readobj(self):
+        """
+        Return a parsed Redis object or an exception
+        when something wrong happened.
+        """
+        while True:
+            obj = self._parser.gets()
+
+            if obj is not False:
+                # TODO: implement resume the read
+
+                # Return any valid object and the Nil->None
+                # case. When its False there is nothing there
+                # to be parsed and we have to wait for more data.
+                return obj
+
+            if self._exception:
+                raise self._exception
+
+            if self._eof:
+                break
+
+            yield from self._wait_for_data('readobj')
+
+    @asyncio.coroutine
+    def _read_not_allowed(self, *args, **kwargs):
+        raise RuntimeError('Use readobj')
+
+    read = _read_not_allowed
+    readline = _read_not_allowed
+    readuntil = _read_not_allowed
+    readexactly = _read_not_allowed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -489,7 +489,7 @@ def _proc():
         for path in tmp_files:
             try:
                 os.remove(path)
-            except FileNotFoundError:
+            except OSError:
                 pass
 
 

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -65,7 +65,7 @@ def test_maxsize(maxsize, create_pool, loop, server):
 
 @pytest.mark.run_loop
 def test_create_connection_timeout(create_pool, loop, server):
-    with patch('asyncio.open_connection') as\
+    with patch.object(loop, 'create_connection') as\
             open_conn_mock:
         open_conn_mock.side_effect = lambda *a, **kw: asyncio.sleep(0.2,
                                                                     loop=loop)

--- a/tests/stream_test.py
+++ b/tests/stream_test.py
@@ -1,0 +1,48 @@
+import pytest
+
+from aioredis.stream import StreamReader
+from aioredis.parser import PyReader
+from aioredis.errors import (
+    ProtocolError,
+    ReplyError
+)
+
+
+@pytest.fixture
+def reader(loop):
+    reader = StreamReader(loop=loop)
+    reader.set_parser(
+        PyReader(protocolError=ProtocolError, replyError=ReplyError)
+    )
+    return reader
+
+
+@pytest.mark.run_loop
+def test_feed_and_parse(reader):
+    reader.feed_data(b'+PONG\r\n')
+    assert (yield from reader.readobj()) == b'PONG'
+
+
+@pytest.mark.run_loop
+def test_buffer_available_after_RST(reader):
+    reader.feed_data(b'+PONG\r\n')
+    reader.set_exception(Exception())
+    assert (yield from reader.readobj()) == b'PONG'
+    with pytest.raises(Exception):
+        yield from reader.readobj()
+
+
+def test_feed_with_eof(reader):
+    reader.feed_eof()
+    with pytest.raises(AssertionError):
+        reader.feed_data(b'+PONG\r\n')
+
+
+@pytest.mark.parametrize(
+    'read_method',
+    ['read', 'readline', 'readuntil', 'readexactly']
+)
+@pytest.mark.run_loop
+def test_read_flavors_not_supported(reader, read_method):
+    with pytest.raises(RuntimeError):
+        yield from getattr(reader, read_method)()

--- a/tests/stream_test.py
+++ b/tests/stream_test.py
@@ -31,11 +31,14 @@ def test_buffer_available_after_RST(reader):
     with pytest.raises(Exception):
         yield from reader.readobj()
 
-
 def test_feed_with_eof(reader):
     reader.feed_eof()
     with pytest.raises(AssertionError):
         reader.feed_data(b'+PONG\r\n')
+
+
+def test_feed_no_data(reader):
+    assert not reader.feed_data(None)
 
 
 @pytest.mark.parametrize(

--- a/tests/stream_test.py
+++ b/tests/stream_test.py
@@ -31,6 +31,7 @@ def test_buffer_available_after_RST(reader):
     with pytest.raises(Exception):
         yield from reader.readobj()
 
+
 def test_feed_with_eof(reader):
     reader.feed_eof()
     with pytest.raises(AssertionError):

--- a/tests/transaction_commands_test.py
+++ b/tests/transaction_commands_test.py
@@ -61,7 +61,7 @@ def test_connection_closed(redis):
     tr = redis.multi_exec()
     fut1 = tr.quit()
     fut2 = tr.incrby('foo', 1.0)
-    fut3 = tr.connection.execute('INCRBY', 'foo', '1.0')
+    fut3 = tr.incrby('foo', 1)
     with pytest.raises(MultiExecError):
         yield from tr.execute()
 


### PR DESCRIPTION
The connection opened with the server uses a customized StreamReader
that get rid of the double buffering between the operating system and
the Redis parser. This also allows _aioredis_ to get rid of a current bug
with abruptly terminated connections.

Current implementation does not allow to keep giving support with
pause/resume the transport if some watermark has been overflowed,
the current implementation of hiredis does not publish the length of the
buffer.

Worth mentioning that doing a micro benchmark [1] the performance gains
observed is a 5%. This has been tested only with the default Asyncio loop. IMHO will worth it a discussion if a _cython_ implementation will help for environments with _uvloop_ ( I think so ).

[1] https://gist.github.com/pfreixes/e320b6f398aa7644c19188ccf2f443b1