### PR TITLE
Correct error message on sentinel discovery of master/slave with password.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ docs/_build/
 # Vim
 .vim
 tests/ssl
+
+# pyenv
+.python-version

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,8 @@ import aioredis.sentinel
 
 TCPAddress = namedtuple('TCPAddress', 'host port')
 
-RedisServer = namedtuple('RedisServer', 'name tcp_address unixsocket version')
+RedisServer = namedtuple('RedisServer',
+                         'name tcp_address unixsocket version password')
 
 SentinelServer = namedtuple('SentinelServer',
                             'name tcp_address unixsocket version masters')
@@ -256,7 +257,7 @@ def start_server(_proc, request, unused_port, server_bin):
             yield True
         raise RuntimeError("Redis startup timeout expired")
 
-    def maker(name, config_lines=None, *, slaveof=None):
+    def maker(name, config_lines=None, *, slaveof=None, password=None):
         assert slaveof is None or isinstance(slaveof, RedisServer), slaveof
         if name in servers:
             return servers[name]
@@ -283,12 +284,16 @@ def start_server(_proc, request, unused_port, server_bin):
                 if unixsocket:
                     write('unixsocket', unixsocket)
                     tmp_files.append(unixsocket)
+                if password:
+                    write('requirepass "{}"'.format(password))
                 write('# extra config')
                 for line in config_lines:
                     write(line)
                 if slaveof is not None:
                     write("slaveof {0.tcp_address.host} {0.tcp_address.port}"
                           .format(slaveof))
+                    if password:
+                        write('masterauth "{}"'.format(password))
             args = [config]
             tmp_files.append(config)
         else:
@@ -302,13 +307,20 @@ def start_server(_proc, request, unused_port, server_bin):
                 args += [
                     '--unixsocket', unixsocket,
                     ]
+            if password:
+                args += [
+                    '--requirepass "{}"'.format(password)
+                    ]
             if slaveof is not None:
                 args += [
                     '--slaveof',
                     str(slaveof.tcp_address.host),
                     str(slaveof.tcp_address.port),
                     ]
-
+                if password:
+                    args += [
+                        '--masterauth "{}"'.format(password)
+                    ]
         f = open(stdout_file, 'w')
         atexit.register(f.close)
         proc = _proc(server_bin, *args,
@@ -331,7 +343,7 @@ def start_server(_proc, request, unused_port, server_bin):
                         print(name, ":", log, end='')
                     if 'sync: Finished with success' in log:
                         break
-        info = RedisServer(name, tcp_address, unixsocket, version)
+        info = RedisServer(name, tcp_address, unixsocket, version, password)
         servers.setdefault(name, info)
         return info
 
@@ -383,6 +395,7 @@ def start_sentinel(_proc, request, unused_port, server_bin):
                       '127.0.0.1', master.tcp_address.port, quorum)
                 write('sentinel down-after-milliseconds', master.name, '3000')
                 write('sentinel failover-timeout', master.name, '3000')
+                write('sentinel auth-pass', master.name, master.password)
 
         f = open(stdout_file, 'w')
         atexit.register(f.close)

--- a/tests/sentinel_commands_test.py
+++ b/tests/sentinel_commands_test.py
@@ -78,6 +78,33 @@ def test_master_info(redis_sentinel, sentinel):
 
 
 @pytest.mark.run_loop
+def test_master__auth(create_sentinel, start_sentinel, start_server, loop):
+    master = start_server('master_1', password='123')
+    start_server('slave_1', slaveof=master, password='123')
+
+    sentinel = start_sentinel('auth_sentinel_1', master)
+    client1 = yield from create_sentinel(
+        [sentinel.tcp_address], password='123', loop=loop)
+
+    client2 = yield from create_sentinel(
+        [sentinel.tcp_address], password='111', loop=loop)
+
+    client3 = yield from create_sentinel(
+        [sentinel.tcp_address], loop=loop)
+
+    m1 = client1.master_for(master.name)
+    yield from m1.set('mykey', 'myval')
+
+    with pytest.raises(ReplyError):
+        m2 = client2.master_for(master.name)
+        yield from m2.set('mykey', 'myval')
+
+    with pytest.raises(ReplyError):
+        m3 = client3.master_for(master.name)
+        yield from m3.set('mykey', 'myval')
+
+
+@pytest.mark.run_loop
 def test_master__unknown(redis_sentinel):
     with pytest.raises(ReplyError):
         yield from redis_sentinel.master('unknown-master')


### PR DESCRIPTION
This will help to get ReplyError "Master X error: ERR invalid password"/"Master X error: NOAUTH Authentication required." instead of MasterNotFoundError "No master found for X" when discovering password protected master/slave via Sentinel without password (or with wrong password) provided.

Pyenv's .python-version config added to .gitignore.