### PR TITLE
Add missing classifier for Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ classifiers = [
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
     'Operating System :: POSIX',
     'Environment :: Web Environment',
     'Intended Audience :: Developers',


### PR DESCRIPTION
SO the list of supported Python versions displayed on PyPI includes 3.6.

Closes #312 