### PR TITLE
Distinct error for futures cancellation

### DIFF
--- a/aioredis/commands/transaction.py
+++ b/aioredis/commands/transaction.py
@@ -2,8 +2,18 @@ import asyncio
 import functools
 
 from ..abc import AbcPool
-from ..errors import RedisError, PipelineError, MultiExecError
-from ..util import wait_ok, async_task, create_future
+from ..errors import (
+    RedisError,
+    PipelineError,
+    MultiExecError,
+    ConnectionClosedError,
+    )
+from ..util import (
+    wait_ok,
+    async_task,
+    create_future,
+    _set_exception,
+    )
 
 
 class TransactionsCommandsMixin:
@@ -255,17 +265,25 @@ class MultiExec(Pipeline):
         exec_ = conn.execute('EXEC')
         gather = asyncio.gather(multi, *coros, loop=self._loop,
                                 return_exceptions=True)
+        last_error = None
         try:
             yield from asyncio.shield(gather, loop=self._loop)
         except asyncio.CancelledError:
             yield from gather
+        except Exception as err:
+            last_error = err
+            raise
         finally:
             if conn.closed:
+                if last_error is None:
+                    last_error = ConnectionClosedError()
                 for fut in waiters:
-                    fut.cancel()
+                    _set_exception(fut, last_error)
+                    # fut.cancel()
                 for fut in self._results:
                     if not fut.done():
-                        fut.cancel()
+                        fut.set_exception(last_error)
+                        # fut.cancel()
             else:
                 try:
                     results = yield from exec_

--- a/aioredis/errors.py
+++ b/aioredis/errors.py
@@ -62,5 +62,9 @@ class ConnectionClosedError(RedisError):
     """Raised if connection to server was closed."""
 
 
+class ConnectionForcedCloseError(ConnectionClosedError):
+    """Raised if connection was closed with .close() method."""
+
+
 class PoolClosedError(RedisError):
     """Raised if pool is closed."""

--- a/tests/integrational_test.py
+++ b/tests/integrational_test.py
@@ -68,7 +68,7 @@ def blocking_pop(pool, val, loop):
         with (yield from pool) as redis:
             # here v0.3 has bound connection, v1.0 does not;
             res = yield from redis.blpop(
-                'list-key', timeout=1, encoding='utf-8')
+                'list-key', timeout=2, encoding='utf-8')
             assert res == ['list-key', 'val'], res
     yield from asyncio.gather(blpop(), lpush(), loop=loop)
 


### PR DESCRIPTION
Cancel pending futures with one of distinct errors (`ConnectionClosedError`, 
`ConnectionForcedCloseError` or builtin exception like `ConnectionError`)
instead of calling `cancel()` method.
