### PR TITLE
Update hscan command to return list of tuples

### DIFF
--- a/aioredis/util.py
+++ b/aioredis/util.py
@@ -86,7 +86,8 @@ class coerced_keys_dict(dict):
         return dict.__contains__(self, other)
 
 
-class _BaseScanIter:
+class _ScanIter:
+
     __slots__ = ('_scan', '_cur', '_ret')
 
     def __init__(self, scan):
@@ -97,25 +98,9 @@ class _BaseScanIter:
     def __aiter__(self):
         return self
 
-
-class _ScanIter(_BaseScanIter):
-
     async def __anext__(self):
         while not self._ret and self._cur:
             self._cur, self._ret = await self._scan(self._cur)
-        if not self._cur and not self._ret:
-            raise StopAsyncIteration  # noqa
-        else:
-            ret = self._ret.pop(0)
-            return ret
-
-
-class _ScanIterPairs(_BaseScanIter):
-
-    async def __anext__(self):
-        while not self._ret and self._cur:
-            self._cur, ret = await self._scan(self._cur)
-            self._ret = list(zip(ret[::2], ret[1::2]))
         if not self._cur and not self._ret:
             raise StopAsyncIteration  # noqa
         else:

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -202,3 +202,37 @@ Sorted set commands (like ``zrange``, ``zrevrange`` and others) that accept
 |        |     assert dict(res) == {b'one': 1, b'two': 2}                     |
 |        |                                                                    |
 +--------+--------------------------------------------------------------------+
+
+
+Hash ``hscan`` command now returns list of tuples
+-------------------------------------------------
+
+``hscan`` updated to return a list of tuples instead of plain
+mixed key/value list.
+
++--------+--------------------------------------------------------------------+
+|        |  .. code-block:: python3                                           |
+| v0.3   |     :emphasize-lines: 4,7-8                                        |
+|        |                                                                    |
+|        |     redis = await aioredis.create_redis(('localhost', 6379))       |
+|        |     await redis.hmset('hash', 'one', 1, 'two', 2)                  |
+|        |     cur, data = await redis.hscan('hash')                          |
+|        |     assert data == [b'one', b'1', b'two', b'2']                    |
+|        |                                                                    |
+|        |     # not an esiest way to make a dict                             |
+|        |     it = iter(data)                                                |
+|        |     assert dict(zip(it, it)) == {b'one': b'1', b'two': b'2'}       |
+|        |                                                                    |
++--------+--------------------------------------------------------------------+
+|        |  .. code-block:: python3                                           |
+| v1.0   |     :emphasize-lines: 4,7                                          |
+|        |                                                                    |
+|        |     redis = await aioredis.create_redis(('localhost', 6379))       |
+|        |     await redis.hmset('hash', 'one', 1, 'two', 2)                  |
+|        |     cur, data = await redis.hscan('hash')                          |
+|        |     assert data == [(b'one', b'1'), (b'two', b'2')]                |
+|        |                                                                    |
+|        |     # now its easier to make a dict of it                          |
+|        |     assert dict(data) == {b'one': b'1': b'two': b'2'}              |
+|        |                                                                    |
++--------+--------------------------------------------------------------------+

--- a/tests/hash_commands_test.py
+++ b/tests/hash_commands_test.py
@@ -371,10 +371,24 @@ async def test_hscan(redis):
         await add(redis, key, f, v)
     # fetch 'field:foo:*' items expected tuple with 3 fields and 3 values
     cursor, values = await redis.hscan(key, match=b'field:foo:*')
-    assert len(values) == 3*2
+    assert len(values) == 3
+    assert sorted(values) == [
+        (b'field:foo:3', b'value:3'),
+        (b'field:foo:6', b'value:6'),
+        (b'field:foo:9', b'value:9'),
+        ]
     # fetch 'field:bar:*' items expected tuple with 7 fields and 7 values
     cursor, values = await redis.hscan(key, match=b'field:bar:*')
-    assert len(values) == 7*2
+    assert len(values) == 7
+    assert sorted(values) == [
+        (b'field:bar:1', b'value:1'),
+        (b'field:bar:10', b'value:10'),
+        (b'field:bar:2', b'value:2'),
+        (b'field:bar:4', b'value:4'),
+        (b'field:bar:5', b'value:5'),
+        (b'field:bar:7', b'value:7'),
+        (b'field:bar:8', b'value:8'),
+        ]
 
     # SCAN family functions do not guarantee that the number of
     # elements returned per call are in a given range. So here
@@ -384,7 +398,7 @@ async def test_hscan(redis):
     while cursor:
         cursor, values = await redis.hscan(key, cursor, count=1)
         test_values.extend(values)
-    assert len(test_values) == 10*2
+    assert len(test_values) == 10
 
     with pytest.raises(TypeError):
         await redis.hscan(None)


### PR DESCRIPTION
It was returning plain list of keys and values (`['field-1', 'value-1', 'field-2', 'value-2']`)
Now: `[('field-1', 'value-1'), ('field-2', 'value-2')]`

Similar to #334 