### PR TITLE
few fixes related to uvloop

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -557,12 +557,6 @@ def pytest_runtest_setup(item):
         item.fixturenames.append('loop')
 
 
-def pytest_ignore_collect(path, config):
-    if 'py35' in str(path):
-        if sys.version_info < (3, 5, 0):
-            return True
-
-
 def pytest_collection_modifyitems(session, config, items):
     for item in items:
         if 'redis_version' in item.keywords:

--- a/tests/connection_test.py
+++ b/tests/connection_test.py
@@ -12,7 +12,7 @@ from aioredis import (
     RedisError,
     ReplyError,
     Channel,
-    MaxClientsError
+    MaxClientsError,
     )
 
 
@@ -113,7 +113,8 @@ async def test_connect_maxclients(create_connection, loop, start_server):
         server.tcp_address, loop=loop)
     await conn.execute(b'CONFIG', b'SET', 'maxclients', 1)
 
-    with pytest.raises((MaxClientsError, ConnectionError)):
+    errors = (MaxClientsError, ConnectionClosedError, ConnectionError)
+    with pytest.raises(errors):
         conn2 = await create_connection(
             server.tcp_address, loop=loop)
         await conn2.execute('ping')

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -459,7 +459,6 @@ async def test_pool_close__used(create_pool, server, loop):
 
 @pytest.mark.run_loop
 @pytest.redis_version(2, 8, 0, reason="maxclients config setting")
-@pytest.mark.xfail(reason="Redis returns 'Err max clients reached'")
 async def test_pool_check_closed_when_exception(
         create_pool, create_redis, start_server, loop):
     server = start_server('server-small')

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -9,7 +9,7 @@ from aioredis import (
     PoolClosedError,
     ConnectionClosedError,
     ConnectionsPool,
-    MaxClientsError
+    MaxClientsError,
     )
 
 
@@ -466,8 +466,9 @@ async def test_pool_check_closed_when_exception(
     redis = await create_redis(server.tcp_address, loop=loop)
     await redis.config_set('maxclients', 2)
 
+    errors = (MaxClientsError, ConnectionClosedError, ConnectionError)
     with pytest.logs('aioredis', 'DEBUG') as cm:
-        with pytest.raises((MaxClientsError, ConnectionError)):
+        with pytest.raises(errors):
             await create_pool(address=tuple(server.tcp_address),
                               minsize=3, loop=loop)
 


### PR DESCRIPTION
* Fix "max clients" tests — uvloop closes connection earlier and so `ConnectionClosedError` is raised;
* Fix aioredis.StreamReader to buffer data until `set_parser` is called — uvloop reads and calls `feed_data` earlier than asyncio loop.