### PR TITLE
Fixed ConnectionsPool.[pubsub_channels/pubsub_patterns]

### DIFF
--- a/aioredis/pool.py
+++ b/aioredis/pool.py
@@ -4,7 +4,7 @@ import types
 
 from .connection import create_connection, _PUBSUB_COMMANDS
 from .log import logger
-from .util import parse_url
+from .util import parse_url, MappingAttributeProxy
 from .errors import PoolClosedError
 from .abc import AbcPool
 from .locks import Lock
@@ -305,15 +305,19 @@ class ConnectionsPool(AbcPool):
 
     @property
     def pubsub_channels(self):
-        if self._pubsub_conn and not self._pubsub_conn.closed:
-            return self._pubsub_conn.pubsub_channels
-        return types.MappingProxyType({})
+        def getter():
+            if self._pubsub_conn and not self._pubsub_conn.closed:
+                return self._pubsub_conn.pubsub_channels
+            return types.MappingProxyType({})
+        return MappingAttributeProxy(getter)
 
     @property
     def pubsub_patterns(self):
-        if self._pubsub_conn and not self._pubsub_conn.closed:
-            return self._pubsub_conn.pubsub_patterns
-        return types.MappingProxyType({})
+        def getter():
+            if self._pubsub_conn and not self._pubsub_conn.closed:
+                return self._pubsub_conn.pubsub_patterns
+            return types.MappingProxyType({})
+        return MappingAttributeProxy(getter)
 
     async def acquire(self, command=None, args=()):
         """Acquires a connection from free pool.

--- a/aioredis/util.py
+++ b/aioredis/util.py
@@ -1,4 +1,5 @@
 from urllib.parse import urlparse, parse_qsl
+import collections
 
 from .log import logger
 
@@ -214,3 +215,17 @@ def _parse_uri_options(params, path, password):
     if 'timeout' in params:
         options['timeout'] = float(params['timeout'])
     return options
+
+
+class MappingAttributeProxy(collections.Mapping):
+    def __init__(self, getter):
+        self._getter = getter
+
+    def __getitem__(self, item):
+        return self._getter()[item]
+
+    def __iter__(self):
+        return self._getter().__iter__()
+
+    def __len__(self):
+        return len(self._getter())


### PR DESCRIPTION
Fixed bug in `commands.pubsub.PubSubCommandsMixin.subscribe` (and psubscribe). `ConnectionsPool.pubsub_channles` code was called before `ConnectionsPool._pubsub_conn` creation, and therefore `pubsub_channles` 