### PR TITLE
fix connections pool get method annotation

### DIFF
--- a/aioredis/pool.py
+++ b/aioredis/pool.py
@@ -440,7 +440,7 @@ class ConnectionsPool(AbcPool):
         '''Return async context manager for working with connection.
 
         async with pool.get() as conn:
-            await conn.get(key)
+            await conn.execute('get', 'my-key')
         '''
         return _AsyncConnectionContextManager(self)
 


### PR DESCRIPTION
pool module ConnectionsPool class get method annotation has error
```python
def get(self):
    '''Return async context manager for working with connection.

       async with pool.get() as conn:
           await conn.get(key)
    '''
    return _AsyncConnectionContextManager(self)
```

Run the following code will raise exception.
```python
import asyncio
import aioredis

loop = asyncio.get_event_loop()

async def go():
    pool = await aioredis.create_pool(
        'redis://localhost',
        minsize=5, maxsize=10,
        loop=loop)
    async with pool.get() as conn:
        await conn.get('key')
    pool.close()
    await pool.wait_closed()

loop.run_until_complete(go())
```
```bash
AttributeError: 'RedisConnection' object has no attribute 'get'
```