### PR TITLE
Sentinel discovery fix

### DIFF
--- a/aioredis/pool.py
+++ b/aioredis/pool.py
@@ -381,11 +381,11 @@ class ConnectionsPool(AbcPool):
     async def _fill_free(self, *, override_min):
         # drop closed connections first
         self._drop_closed()
-        address = self._address
+        # address = self._address
         while self.size < self.minsize:
             self._acquiring += 1
             try:
-                conn = await self._create_new_connection(address)
+                conn = await self._create_new_connection(self._address)
                 # check the healthy of that connection, if
                 # something went wrong just trigger the Exception
                 await conn.execute('ping')
@@ -400,7 +400,7 @@ class ConnectionsPool(AbcPool):
             while not self._pool and self.size < self.maxsize:
                 self._acquiring += 1
                 try:
-                    conn = await self._create_new_connection(address)
+                    conn = await self._create_new_connection(self._address)
                     self._pool.append(conn)
                 finally:
                     self._acquiring -= 1


### PR DESCRIPTION
Fix issue with Sentinel client and ConnectionsPool causing endless reconnect on service discovery.

`ConnectionsPool._fill_free` was always calling `ManagedPool._create_new_connection` with `_NON_DISCOVERED` address marker causing `ManagedPool` to clear all currently established connections.
So setting `minsize` value greater then 1 was putting  `_fill_free` in endless loop.