### PR TITLE
reduce encode_command cost about 60%+

### DIFF
--- a/aioredis/util.py
+++ b/aioredis/util.py
@@ -15,6 +15,7 @@ _converters = {
     float: lambda val: b'%r' % val,
 }
 
+
 def encode_command(*args):
     """Encodes arguments into redis bulk-strings array.
 
@@ -27,10 +28,11 @@ def encode_command(*args):
         for arg in args:
             barg = _converters[type(arg)](arg)
             buf.extend(b'$%d\r\n%s\r\n' % (len(barg), barg))
-    except:
+    except KeyError as exc:
         raise TypeError("Argument {!r} expected to be of bytearray, bytes,"
                         " float, int, or str type".format(arg))
     return buf
+
 
 def decode(obj, encoding):
     if isinstance(obj, bytes):


### PR DESCRIPTION
`
import time

_converters = {
    bytes: lambda val: val,
    bytearray: lambda val: val,
    str: lambda val: val.encode(),
    int: lambda val: b'%d' % val,
    float: lambda val: b'%r' % val,
}

def encode_command(*args):
    """Encodes arguments into redis bulk-strings array.

    Raises TypeError if any of args not of bytearray, bytes, float, int, or str
    type.
    """
    buf = bytearray(b'*%d\r\n' % len(args))

    try:
        for arg in args:
            barg = _converters[type(arg)](arg)
            buf.extend(b'$%d\r\n%s\r\n' % (len(barg), barg))
    except:
        raise TypeError("Argument {!r} expected to be of bytearray, bytes,"
                        " float, int, or str type".format(arg))
    return buf


_converters_old = {
    bytes: lambda val: val,
    bytearray: lambda val: val,
    str: lambda val: val.encode('utf-8'),
    int: lambda val: str(val).encode('utf-8'),
    float: lambda val: str(val).encode('utf-8'),
}


def _bytes_len(sized):
    return str(len(sized)).encode('utf-8')


def encode_command_old(*args):
    """Encodes arguments into redis bulk-strings array.

    Raises TypeError if any of args not of bytearray, bytes, float, int, or str
    type.
    """
    buf = bytearray()

    def add(data):
        return buf.extend(data + b'\r\n')

    add(b'*' + _bytes_len(args))
    for arg in args:
        if type(arg) in _converters:
            barg = _converters_old[type(arg)](arg)
            add(b'$' + _bytes_len(barg))
            add(barg)
        else:
            raise TypeError("Argument {!r} expected to be of bytearray, bytes,"
                            " float, int, or str type".format(arg))
    return buf



t1 = time.time()
for i in range(10000):
    foo = encode_command(123, "abc", 4.567, b'890jqk')
print(time.time()-t1)
t1 = time.time()
for i in range(10000):
    bar = encode_command_old(123, "abc", 4.567, b'890jqk')
print(time.time()-t1)

assert foo == bar
`
on my mbp, the result is:

0.04150104522705078
0.09163022041320801