### PR TITLE
Update supported python versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ SSL/TLS support                     Yes
 Sentinel support                    Yes
 Redis Cluster support               WIP
 Trollius (python 2.7)               No
-Tested CPython versions             `3.5, 3.6 3.7 <travis_>`_ [2]_
+Tested CPython versions             `3.5.3+, 3.6, 3.7 <travis_>`_ [2]_
 Tested PyPy3 versions               `5.9.0 <travis_>`_
 Tested for Redis server             `2.6, 2.8, 3.0, 3.2, 4.0 <travis_>`_
 Support for dev Redis server        through low-level API

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,7 @@ Pub/Sub support                     Yes
 Sentinel support                    Yes [1]_
 Redis Cluster support               WIP
 Trollius (python 2.7)               No
-Tested CPython versions             `3.5, 3.6 <travis_>`_ [2]_
+Tested CPython versions             `3.5.3+, 3.6, 3.7 <travis_>`_ [2]_
 Tested PyPy3 versions               `5.9.0 <travis_>`_
 Tested for Redis server             `2.6, 2.8, 3.0, 3.2, 4.0 <travis_>`_
 Support for dev Redis server        through low-level API

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ if platform.python_implementation() == 'CPython':
 
 PY_VER = sys.version_info
 
-if PY_VER < (3, 5):
-    raise RuntimeError("aioredis doesn't support Python version prior 3.5")
+if PY_VER < (3, 5, 3):
+    raise RuntimeError("aioredis doesn't support Python version prior 3.5.3")
 
 
 def read(*parts):
@@ -61,6 +61,7 @@ setup(name='aioredis',
       url="https://github.com/aio-libs/aioredis",
       license="MIT",
       packages=find_packages(exclude=["tests"]),
+      python_requires=">=3.5.3",
       install_requires=install_requires,
       include_package_data=True,
       )


### PR DESCRIPTION
- 3.7 was not mentioned everywhere
- minimal requirement is Python 3.5.3, not Python 3.5 (according to readme)