### PR TITLE
Adjust tests for redis 5

### DIFF
--- a/tests/server_commands_test.py
+++ b/tests/server_commands_test.py
@@ -35,6 +35,8 @@ async def test_client_list(redis, server, request):
         }
     if server.version >= (2, 8, 12):
         expected['id'] = mock.ANY
+    if server.version >= (5, ):
+        expected['qbuf'] = '26'
     assert expected in res
 
 
@@ -68,6 +70,8 @@ async def test_client_list__unixsocket(create_redis, loop, server, request):
         }
     if server.version >= (2, 8, 12):
         expected['id'] = mock.ANY
+    if server.version >= (5, ):
+        expected['qbuf'] = '26'
     assert expected in info
 
 


### PR DESCRIPTION
The tests on master are failing.  See eg. https://travis-ci.com/michael-k/aioredis/builds/84230401

I do not know enough about the redis internals to explain why this change is necessary, but it fixes the tests and the same adjustment was done in redis' test suite.

See https://github.com/antirez/redis/blob/5.0-rc5/00-RELEASENOTES#L191-L193 and https://github.com/antirez/redis/commit/1203a04f5e6b7fe78162080e3ebf32ee71329785