### PR TITLE
bug in _drop_closed

### DIFF
--- a/aioredis/pool.py
+++ b/aioredis/pool.py
@@ -376,7 +376,7 @@ class ConnectionsPool(AbcPool):
             if conn.closed:
                 self._pool.popleft()
             else:
-                self._pool.rotate(1)
+                self._pool.rotate(-1)
 
     async def _fill_free(self, *, override_min):
         # drop closed connections first


### PR DESCRIPTION
`ConnectionsPool._drop_closed` does not really drop all closed connections. One can see the flaw in the algorithm by running the following simplified example:
```python
from collections import deque

def drop_closed(q):
   for i in range(len(q)):
       if q[0] == 'C':
          q.popleft()
       else:
          q.rotate(1)


q = deque(['O', 'C', 'C'])
drop_closed(q)
print(q)
```
This patch (hopefully) fixes this problem.