### PR TITLE
Fix slow memory leak in `wait_closed` implementation

### DIFF
--- a/aioredis/pool.py
+++ b/aioredis/pool.py
@@ -4,7 +4,7 @@ import types
 
 from .connection import create_connection, _PUBSUB_COMMANDS
 from .log import logger
-from .util import parse_url
+from .util import parse_url, CloseEvent
 from .errors import PoolClosedError
 from .abc import AbcPool
 from .locks import Lock
@@ -57,6 +57,7 @@ async def create_pool(address, *, db=None, password=None, ssl=None,
     except Exception:
         pool.close()
         await pool.wait_closed()
+        await pool.wait_closed()
         raise
     return pool
 
@@ -91,8 +92,7 @@ class ConnectionsPool(AbcPool):
         self._used = set()
         self._acquiring = 0
         self._cond = asyncio.Condition(lock=Lock(loop=loop), loop=loop)
-        self._close_state = asyncio.Event(loop=loop)
-        self._close_waiter = None
+        self._close_state = CloseEvent(self._do_close, loop=loop)
         self._pubsub_conn = None
         self._connection_cls = connection_cls
 
@@ -142,7 +142,6 @@ class ConnectionsPool(AbcPool):
         await asyncio.gather(*waiters, loop=self._loop)
 
     async def _do_close(self):
-        await self._close_state.wait()
         async with self._cond:
             assert not self._acquiring, self._acquiring
             waiters = []
@@ -161,13 +160,6 @@ class ConnectionsPool(AbcPool):
         """Close all free and in-progress connections and mark pool as closed.
         """
         if not self._close_state.is_set():
-            async def close():
-                try:
-                    await self._do_close()
-                finally:
-                    self._close_waiter = None
-            self._close_waiter = asyncio.ensure_future(close(),
-                                                       loop=self._loop)
             self._close_state.set()
 
     @property
@@ -177,11 +169,7 @@ class ConnectionsPool(AbcPool):
 
     async def wait_closed(self):
         """Wait until pool gets closed."""
-        if self._close_state.is_set():
-            return
         await self._close_state.wait()
-        assert self._close_waiter is not None
-        await asyncio.shield(self._close_waiter, loop=self._loop)
 
     @property
     def db(self):

--- a/aioredis/util.py
+++ b/aioredis/util.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from urllib.parse import urlparse, parse_qsl
 
 from .log import logger
@@ -207,3 +209,30 @@ def _parse_uri_options(params, path, password):
     if 'timeout' in params:
         options['timeout'] = float(params['timeout'])
     return options
+
+
+class CloseEvent:
+    def __init__(self, on_close, loop=None):
+        self._close_init = asyncio.Event(loop=loop)
+        self._close_done = asyncio.Event(loop=loop)
+        self._on_close = on_close
+        self._loop = loop
+
+    async def wait(self):
+        await self._close_init.wait()
+        await self._close_done.wait()
+
+    def is_set(self):
+        return self._close_done.is_set() or self._close_init.is_set()
+
+    def set(self):
+        if self._close_init.is_set():
+            return
+
+        task = asyncio.ensure_future(self._on_close(), loop=self._loop)
+        task.add_done_callback(self._cleanup)
+        self._close_init.set()
+
+    def _cleanup(self, task):
+        self._on_close = None
+        self._close_done.set()

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -19,7 +19,7 @@ def _assert_defaults(pool):
     assert pool.maxsize == 10
     assert pool.size == 1
     assert pool.freesize == 1
-    assert pool._close_waiter is None
+    assert not pool._close_state.is_set()
 
 
 def test_connect(pool):


### PR DESCRIPTION
When calling `ConnectionsPool.close()` method `_do_close` task is scheduled and stored in
`_close_waiter` attribute which is then awaited in `wait_closed()` method.
Somehow this was causing `_do_close` to stuck in envent loop `asyncio.Taks.all_tasks` in status `finished`.

Fixes #496 