### PR TITLE
tests: upgrade pytest to 4.1.1

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -609,6 +609,11 @@ def pytest_configure(config):
                 "Can not import uvloop, make sure it is installed")
         asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
+    # Stopgap for removed pytest_namespace hook.
+    pytest.assert_almost_equal = assert_almost_equal
+    pytest.logs = logs
+    pytest.redis_version = redis_version
+
 
 def logs(logger, level=None):
     """Catches logs for given logger and level.
@@ -696,11 +701,3 @@ def assert_almost_equal(first, second, places=None, msg=None, delta=None):
         assert abs(first - second) <= delta
     else:
         assert round(abs(first - second), places) == 0
-
-
-def pytest_namespace():
-    return {
-        'assert_almost_equal': assert_almost_equal,
-        'redis_version': redis_version,
-        'logs': logs,
-        }

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 hiredis==0.3.0
 flake8==3.6.0
 coverage==4.5.2
-pytest==4.0.1
+pytest==4.1.1
 pytest-cov==2.6.0
 pytest-xdist==1.24.1
 async-timeout==3.0.1


### PR DESCRIPTION
Uses stopgap measure for removed pytest_namespace hook.

Closes https://github.com/aio-libs/aioredis/pull/513.