### PR TITLE
Add _invalid password_ to AuthError error matches

### DIFF
--- a/aioredis/errors.py
+++ b/aioredis/errors.py
@@ -47,7 +47,11 @@ class MaxClientsError(ReplyError):
 class AuthError(ReplyError):
     """Raised when authentication errors occurs."""
 
-    MATCH_REPLY = ("NOAUTH ", "ERR invalid password")
+    MATCH_REPLY = (
+        "NOAUTH ",
+        "ERR invalid password",
+        "ERR Client sent AUTH, but no password is set",
+    )
 
 
 class PipelineError(RedisError):


### PR DESCRIPTION
Didn't add tests since this case already covered in `tests/connection_commands_test.py:test_auth`
