### PR TITLE
ss18/pr0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -349,7 +349,7 @@ Changes
 * Fixed cancellation of wait_closed
   (see `#118 <https://github.com/aio-libs/aioredis/issues/118>`_);
 
-* Fixed ``time()`` convertion to float
+* Fixed ``time()`` conversion to float
   (see `#126 <https://github.com/aio-libs/aioredis/issues/126>`_);
 
 * Fixed ``hmset()`` method to return bool instead of ``b'OK'``

--- a/tests/connection_commands_test.py
+++ b/tests/connection_commands_test.py
@@ -90,7 +90,7 @@ async def test_encoding(create_redis, loop, server):
 
 
 @pytest.mark.run_loop
-async def test_yield_from_backwards_compatability(create_redis, server, loop):
+async def test_yield_from_backwards_compatibility(create_redis, server, loop):
     redis = await create_redis(server.tcp_address, loop=loop)
 
     assert isinstance(redis, Redis)

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -310,7 +310,7 @@ async def test_select_and_create(create_pool, loop, server):
     # trying to model situation when select and acquire
     # called simultaneously
     # but acquire freezes on _wait_select and
-    # then continues with propper db
+    # then continues with proper db
 
     # TODO: refactor this test as there's no _wait_select any more.
     with async_timeout.timeout(10, loop=loop):

--- a/tests/pubsub_commands_test.py
+++ b/tests/pubsub_commands_test.py
@@ -41,7 +41,7 @@ async def test_publish_json(create_connection, redis, server, loop):
     await fut
 
     res = await redis.publish_json('chan:1', {"Hello": "world"})
-    assert res == 1    # recievers
+    assert res == 1    # receivers
 
     msg = await out.get()
     assert msg == b'{"Hello": "world"}'


### PR DESCRIPTION
Fixed typos:
compatability -> compatibility
convertion -> conversion
recievers -> receivers
propper -> proper

Found with: https://github.com/ss18/grep-typos