### PR TITLE
Implementation of redis locks (for single redis masters)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,8 @@ Changes
 
 .. towncrier release notes start
 
+43.feature
+
 1.2.0 (2018-10-24)
 ^^^^^^^^^^^^^^^^^^
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -27,6 +27,7 @@ Manuel Miranda
 Marek Szapiel
 Marijn Giesen
 Martin <the-panda>
+Matt Rasband
 Maxim Dodonchuk
 Michael Käufl
 Nickolai Novik

--- a/aioredis/__init__.py
+++ b/aioredis/__init__.py
@@ -25,6 +25,7 @@ from .errors import (
     SlaveNotFoundError,
     MasterReplyError,
     SlaveReplyError,
+    LockTimeoutError,
     )
 
 
@@ -63,4 +64,5 @@ __all__ = [
     'ReadOnlyError',
     'MasterReplyError',
     'SlaveReplyError',
+    'LockTimeoutError',
 ]

--- a/aioredis/commands/generic.py
+++ b/aioredis/commands/generic.py
@@ -1,3 +1,4 @@
+from aioredis.locks import RedisLock
 from aioredis.util import wait_convert, wait_ok, _NOTSET, _ScanIter
 
 
@@ -305,3 +306,10 @@ class GenericCommandsMixin:
         commands sent in the context of the current connection.
         """
         return self.execute(b'WAIT', numslaves, timeout)
+
+    def lock(self, key, timeout=30, wait_timeout=30):
+        """Obtain a distributed lock on the key.
+
+        This lock is not the 'redlock' algorithm and is the simpler,
+        single-node locking mechanism."""
+        return RedisLock(self, key, timeout, wait_timeout)

--- a/aioredis/commands/generic.py
+++ b/aioredis/commands/generic.py
@@ -310,6 +310,6 @@ class GenericCommandsMixin:
     def lock(self, key, timeout=30, wait_timeout=30):
         """Obtain a distributed lock on the key.
 
-        This lock is not the 'redlock' algorithm and is the simpler,
-        single-node locking mechanism."""
+        This lock is the simpler, single node locking mechanism.
+        """
         return RedisLock(self, key, timeout, wait_timeout)

--- a/aioredis/errors.py
+++ b/aioredis/errors.py
@@ -16,6 +16,7 @@ __all__ = [
     'MasterNotFoundError',
     'SlaveNotFoundError',
     'ReadOnlyError',
+    'LoLockTimeoutError',
     ]
 
 
@@ -112,3 +113,7 @@ class ConnectionForcedCloseError(ConnectionClosedError):
 
 class PoolClosedError(RedisError):
     """Raised if pool is closed."""
+
+
+class LockTimeoutError(Exception):
+    """Raised if a lock is unable to be acquired within the timeout"""

--- a/aioredis/errors.py
+++ b/aioredis/errors.py
@@ -16,7 +16,7 @@ __all__ = [
     'MasterNotFoundError',
     'SlaveNotFoundError',
     'ReadOnlyError',
-    'LoLockTimeoutError',
+    'LockTimeoutError',
     ]
 
 

--- a/aioredis/locks.py
+++ b/aioredis/locks.py
@@ -151,7 +151,7 @@ class RedisLock:
         while True:
             if await self._script_exec(
                 self._acquire_script,
-                keys=[self._key],
+                keys=[key],
                 args=[self._token, timeout * 1000]
             ):
                 return True

--- a/aioredis/locks.py
+++ b/aioredis/locks.py
@@ -5,6 +5,8 @@ import time
 from asyncio.locks import Lock as _Lock
 from asyncio import coroutine
 
+from .errors import LockTimeoutError
+
 # Fixes an issue with all Python versions that leaves pending waiters
 # without being awakened when the first waiter is canceled.
 # Code adapted from the PR https://github.com/python/cpython/pull/1031
@@ -44,10 +46,6 @@ class Lock(_Lock):
             if not fut.done():
                 fut.set_result(True)
                 break
-
-
-class UnableToLockError(Exception):
-    pass
 
 
 class RedisLock:
@@ -130,7 +128,7 @@ class RedisLock:
         if await self.acquire(self._key, self._timeout, self._wait_timeout):
             return self
 
-        raise UnableToLockError("Unable to acquire lock within timeout")
+        raise LockTimeoutError("Unable to acquire lock within timeout")
 
     async def __aexit__(self, *args, **kwargs):
         await self.release()

--- a/aioredis/locks.py
+++ b/aioredis/locks.py
@@ -116,11 +116,17 @@ class RedisLock:
         Register the required scripts with redis
         """
         if self._acquire_script is None:
-            self._acquire_script = await self._pool_or_conn.script_load(self.ACQUIRE_SCRIPT)
+            self._acquire_script = (
+                await self._pool_or_conn.script_load(self.ACQUIRE_SCRIPT)
+            )
         if self._release_script is None:
-            self._release_script = await self._pool_or_conn.script_load(self.RELEASE_SCRIPT)
+            self._release_script = (
+                await self._pool_or_conn.script_load(self.RELEASE_SCRIPT)
+            )
         if self._extend_script is None:
-            self._extend_script = await self._pool_or_conn.script_load(self.EXTEND_SCRIPT)
+            self._extend_script = (
+                await self._pool_or_conn.script_load(self.EXTEND_SCRIPT)
+            )
 
     async def __aenter__(self):
         await self.register_scripts()

--- a/aioredis/locks.py
+++ b/aioredis/locks.py
@@ -1,4 +1,6 @@
 import asyncio
+import secrets
+import time
 
 from asyncio.locks import Lock as _Lock
 from asyncio import coroutine
@@ -42,3 +44,151 @@ class Lock(_Lock):
             if not fut.done():
                 fut.set_result(True)
                 break
+
+
+class UnableToLockError(Exception):
+    pass
+
+
+class RedisLock:
+    """
+    This is the simple implementation from the redis documentation for
+    distributed locking, influenced by redis-py's implementation.
+    """
+
+    # Script to acquire the lock and make sure it will expire
+    # eventually
+    # param: keys[1] - key to lock on (shared)
+    # param: argv[1] - this lock's token (unique)
+    # param: argv[2] - expiration in milliseconds
+    ACQUIRE_SCRIPT = """
+        if redis.call('setnx', KEYS[1], ARGV[1]) == 1 then
+            redis.call('pexpire', KEYS[1], ARGV[2])
+            return 1
+        else
+            return 0
+        end
+    """
+
+    # Script to release the lock, this will only delete
+    # the lock token if it's the one from this lock instance
+    # param: keys[1] - key to lock on (shared)
+    # param: args[1] - this lock's token (unique)
+    # returns: 1 if released, otherwise 0
+    RELEASE_SCRIPT = """
+        if redis.call('get', KEYS[1]) == ARGV[1] then
+            return redis.call('del', KEYS[1])
+        else
+            return 0
+        end
+    """
+
+    # Extend the lock, this will only extend if the
+    # current lock holder is this lock instance.
+    # param: keys[1] - key to lock on (shared)
+    # param: args[1] - this lock's token (unique)
+    # param: args[2] - additional millis to keep the lock
+    # returns: 1 if extended, otherwise 0
+    EXTEND_SCRIPT = """
+        if redis.call('get', KEYS[1]) ~= ARGV[1] then
+            return 0
+        end
+
+        local expiration = redis.call('pttl', KEYS[1])
+        if expiration < 0 then
+            return 0
+        end
+        redis.call('pexpire', KEYS[1], expiration + ARGV[2])
+        return 1
+    """
+
+    def __init__(self, pool_or_conn, key, timeout=30, wait_timeout=30):
+        self._pool_or_conn = pool_or_conn
+        self._key = key
+        self._timeout = timeout
+        self._wait_timeout = wait_timeout
+        self._token = secrets.token_hex(6)
+
+        self._acquire_script = None
+        self._extend_script = None
+        self._release_script = None
+
+    async def register_scripts(self):
+        """
+        Register the required scripts with redis
+        """
+        if self._acquire_script is None:
+            self._acquire_script = await self._pool_or_conn.script_load(self.ACQUIRE_SCRIPT)
+        if self._release_script is None:
+            self._release_script = await self._pool_or_conn.script_load(self.RELEASE_SCRIPT)
+        if self._extend_script is None:
+            self._extend_script = await self._pool_or_conn.script_load(self.EXTEND_SCRIPT)
+
+    async def __aenter__(self):
+        await self.register_scripts()
+
+        if await self.acquire(self._key, self._timeout, self._wait_timeout):
+            return self
+
+        raise UnableToLockError("Unable to acquire lock within timeout")
+
+    async def __aexit__(self, *args, **kwargs):
+        await self.release()
+
+    async def acquire(self, key, timeout=30, wait_timeout=30):
+        """
+        Attempt to acquire the lock
+        :param key: Lock key
+        :param timeout: Number of seconds until the lock should timeout. It can
+                        be extended via extend
+        :param wait_timeout: How long to wait before aborting the lock request
+        """
+        start = int(time.time())
+        while True:
+            if await self._script_exec(
+                self._acquire_script,
+                keys=[self._key],
+                args=[self._token, timeout * 1_000]
+            ):
+                return True
+
+            if int(time.time()) - start > wait_timeout:
+                return False
+            await asyncio.sleep(0.1)
+
+    async def extend(self, added_time):
+        """
+        Extend the lock by the amount of time, this will only extend
+        if this instance owns the lock.
+
+        :param added_time: Number of seconds to add to the lock expiration
+        :returns: 1 if the extend was successful, 0 otherwise
+        """
+        return await self._script_exec(
+            self._extend_script,
+            keys=[self._key],
+            args=[self._token, added_time * 1_000],
+        )
+
+    async def release(self):
+        """
+        Release the lock, this will only release if this instance of the lock
+        is the one holding the lock.
+
+        :returns: 1 if the release was successful, 0 otherwise.
+        """
+        return await self._script_exec(
+            self._release_script,
+            keys=[self._key],
+            args=[self._token]
+        )
+
+    async def _script_exec(self, sha, keys, args):
+        """
+        Execute the script with the provided keys and args.
+
+        :param sha: Script sha, returned after the script was loaded
+        :param keys: Keys to the script
+        :param args: Args to the script
+        """
+        return await self._pool_or_conn.evalsha(sha, keys=keys, args=args)

--- a/aioredis/locks.py
+++ b/aioredis/locks.py
@@ -152,7 +152,7 @@ class RedisLock:
             if await self._script_exec(
                 self._acquire_script,
                 keys=[self._key],
-                args=[self._token, timeout * 1_000]
+                args=[self._token, timeout * 1000]
             ):
                 return True
 
@@ -171,7 +171,7 @@ class RedisLock:
         return await self._script_exec(
             self._extend_script,
             keys=[self._key],
-            args=[self._token, added_time * 1_000],
+            args=[self._token, added_time * 1000],
         )
 
     async def release(self):

--- a/aioredis/locks.py
+++ b/aioredis/locks.py
@@ -1,6 +1,6 @@
 import asyncio
-import secrets
 import time
+import uuid
 
 from asyncio.locks import Lock as _Lock
 from asyncio import coroutine
@@ -105,7 +105,7 @@ class RedisLock:
         self._key = key
         self._timeout = timeout
         self._wait_timeout = wait_timeout
-        self._token = secrets.token_hex(6)
+        self._token = str(uuid.uuid4())
 
         self._acquire_script = None
         self._extend_script = None

--- a/tests/generic_commands_test.py
+++ b/tests/generic_commands_test.py
@@ -6,8 +6,7 @@ import sys
 
 from unittest import mock
 
-from aioredis import ReplyError
-from aioredis.locks import UnableToLockError
+from aioredis import ReplyError, LockTimeoutError
 from _testutils import redis_version, assert_almost_equal
 
 
@@ -802,8 +801,7 @@ async def test_wait(redis, loop):
 
 @pytest.mark.run_loop
 async def test_lock(redis):
-
-    with pytest.raises(UnableToLockError):
+    with pytest.raises(LockTimeoutError):
         async with redis.lock("key", timeout=5):
             async with redis.lock("key", wait_timeout=2):
                 pass

--- a/tests/generic_commands_test.py
+++ b/tests/generic_commands_test.py
@@ -808,3 +808,11 @@ async def test_lock(redis):
             assert False
 
     assert (await redis.get("key")) is None
+
+    # ensure the lock is not deleted by the release if it's changed
+    async with redis.lock("key"):
+        await redis.set("key", "some_other_string")
+
+    assert (await redis.get("key")) == b"some_other_string"
+
+    await redis.delete("key")

--- a/tests/generic_commands_test.py
+++ b/tests/generic_commands_test.py
@@ -7,6 +7,7 @@ import sys
 from unittest import mock
 
 from aioredis import ReplyError
+from aioredis.locks import UnableToLockError
 from _testutils import redis_version, assert_almost_equal
 
 
@@ -797,3 +798,15 @@ async def test_wait(redis, loop):
     end = await redis.time()
     assert res == 0
     assert end - start < .4
+
+
+@pytest.mark.run_loop
+async def test_lock(redis):
+
+    with pytest.raises(UnableToLockError):
+        async with redis.lock("key", timeout=5):
+            async with redis.lock("key", wait_timeout=2):
+                pass
+            assert False
+
+    assert redis.get("key") is None

--- a/tests/generic_commands_test.py
+++ b/tests/generic_commands_test.py
@@ -807,4 +807,4 @@ async def test_lock(redis):
                 pass
             assert False
 
-    assert redis.get("key") is None
+    assert (await redis.get("key")) is None


### PR DESCRIPTION
## What do these changes do?

Provide an implementation of locking utilizing redis

## Are there changes in behavior for the user?

Users now have a `.lock` method on the GenericCommandsMixin, but it's optional path.

## Related issue number

#43 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
