### PR TITLE
Add demo of sharing pool from multiple coroutines

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,6 +127,40 @@ Simple high-level interface with connections pool:
     loop.run_until_complete(go())
     # will print 'value'
 
+Using a pool among multiple coroutine calls:
+
+.. code:: python
+
+    import asyncio
+    import string
+
+    import aioredis
+
+    async def go(r, key, value):
+        await r.set(key, value)
+        val = await r.get(key)
+        print(f"Got {key} -> {val}")
+
+    async def main(loop):
+        try:
+            r = await aioredis.create_redis_pool(
+                "redis://localhost", minsize=5, maxsize=10, loop=loop
+            )
+            return await asyncio.gather(
+                *(
+                    go(r, i, j)
+                    for i, j in zip(string.ascii_uppercase, string.ascii_lowercase)
+                ),
+                return_exceptions=True,
+            )
+        finally:
+            r.close()
+            await r.wait_closed()
+
+    if __name__ == "__main__":
+        loop = asyncio.get_event_loop()
+        res = loop.run_until_complete(main(loop))
+
 Requirements
 ------------
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add a small example in the README showing usage of a single `pool` from multiple coroutines.

In the current README, it is not obvious for someone new to async io that the connection should only be closed once from the top-level caller.
