### PR TITLE
Add project specific PR template, including CONTRIBUTORS.txt

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@
 - [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
   * The format is `<Name> <Surname>`.
   * Please keep alphabetical order, the file is sorted by names. 
-- [ ] Add a new news fragment into the `CHANGES` folder
+- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
   * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
   * if you don't have an `issue_id` change it to the pr id after creating the PR
   * ensure type is one of the following:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!-- Thank you for your contribution! -->
+
+## What do these changes do?
+
+<!-- Please give a short brief about these changes. -->
+
+## Are there changes in behavior for the user?
+
+<!-- Outline any notable behaviour for the end users. -->
+
+## Related issue number
+
+<!-- Are there any issues opened that will be resolved by merging this change? -->
+
+## Checklist
+
+- [ ] I think the code is well written
+- [ ] Unit tests for the changes exist
+- [ ] Documentation reflects the changes
+- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
+  * The format is `<Name> <Surname>`.
+  * Please keep alphabetical order, the file is sorted by names. 
+- [ ] Add a new news fragment into the `CHANGES` folder
+  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
+  * if you don't have an `issue_id` change it to the pr id after creating the PR
+  * ensure type is one of the following:
+    * `.feature`: Signifying a new feature.
+    * `.bugfix`: Signifying a bug fix.
+    * `.doc`: Signifying a documentation improvement.
+    * `.removal`: Signifying a deprecation or removal of public API.
+    * `.misc`: A ticket has been closed, but it is not of interest to users.
+  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -29,4 +29,5 @@
     * `.doc`: Signifying a documentation improvement.
     * `.removal`: Signifying a deprecation or removal of public API.
     * `.misc`: A ticket has been closed, but it is not of interest to users.
-  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
+  * Make sure to use full sentences with correct case and punctuation, for example:
+   `Fix issue with non-ascii contents in doctest text files.`


### PR DESCRIPTION
Add aioredis-specific PR template, that includes CONTRIBUTORS.txt

Related to proposed PR for removing CONTRIBUTORS.txt from the global PR template
https://github.com/aio-libs/.github/pull/3