### PR TITLE
Handling case where redis returns phantom stream messages with no fields

### DIFF
--- a/CHANGES/605.bugfix
+++ b/CHANGES/605.bugfix
@@ -1,0 +1,1 @@
+Fix handling of instances were Redis returns null fields for a stream message

--- a/aioredis/commands/streams.py
+++ b/aioredis/commands/streams.py
@@ -33,7 +33,7 @@ def parse_messages(messages):
     """
     if messages is None:
         return []
-    return [(mid, fields_to_dict(values)) for mid, values in messages]
+    return [(mid, fields_to_dict(values)) for mid, values in messages if values is not None]
 
 
 def parse_messages_by_stream(messages_by_stream):

--- a/aioredis/commands/streams.py
+++ b/aioredis/commands/streams.py
@@ -33,6 +33,8 @@ def parse_messages(messages):
     """
     if messages is None:
         return []
+
+    messages = (message for message in messages if message is not None)
     return [
         (mid, fields_to_dict(values))
         for mid, values

--- a/aioredis/commands/streams.py
+++ b/aioredis/commands/streams.py
@@ -33,7 +33,11 @@ def parse_messages(messages):
     """
     if messages is None:
         return []
-    return [(mid, fields_to_dict(values)) for mid, values in messages if values is not None]
+    return [
+        (mid, fields_to_dict(values))
+        for mid, values
+        in messages if values is not None
+    ]
 
 
 def parse_messages_by_stream(messages_by_stream):

--- a/tests/stream_commands_test.py
+++ b/tests/stream_commands_test.py
@@ -4,6 +4,7 @@ import asyncio
 from collections import OrderedDict
 from unittest import mock
 
+from aioredis.commands.streams import parse_messages
 from aioredis.errors import BusyGroupError
 from _testutils import redis_version
 
@@ -559,3 +560,15 @@ async def test_xread_param_types(redis, param):
             ["system_event_stream"],
             timeout=param, latest_ids=[0]
         )
+
+
+def test_parse_messages_ok():
+    message = [(b'123', [b'f1', b'v1', b'f2', b'v2'])]
+    assert parse_messages(message) == [(b'123', {b'f1': b'v1', b'f2': b'v2'})]
+
+
+def test_parse_messages_null():
+    # Redis can sometimes respond with a fields value of 'null',
+    # so ensure we handle that sensibly
+    message = [(b'123', None)]
+    assert parse_messages(message) == []

--- a/tests/stream_commands_test.py
+++ b/tests/stream_commands_test.py
@@ -567,8 +567,15 @@ def test_parse_messages_ok():
     assert parse_messages(message) == [(b'123', {b'f1': b'v1', b'f2': b'v2'})]
 
 
-def test_parse_messages_null():
+def test_parse_messages_null_fields():
     # Redis can sometimes respond with a fields value of 'null',
     # so ensure we handle that sensibly
     message = [(b'123', None)]
+    assert parse_messages(message) == []
+
+
+def test_parse_messages_null_message():
+    # Redis can sometimes respond with a fields value of 'null',
+    # so ensure we handle that sensibly
+    message = [None]
     assert parse_messages(message) == []


### PR DESCRIPTION
## What do these changes do?

aioredis will now ignore streams messages which have a `(null)` value for the fields. An example of such a response from Redis:

```
XREADGROUP GROUP fp.sales-store_stock_level_in_cache web-5689899cfc-bsgsl STREAMS production.statistics.*:stream 0
1) 1) "production.statistics.*:stream"
   2)  1) 1) "1559345885072-0"
          2) (nil)
```

I could only recreate this behaviour using `XREADGROUP`, not `XREAD`. Furthermore, Redis reported there were no messages matching this message ID:

```
XRANGE production.statistics.*:stream 1559345885072-0 1559345885072-0
(empty list or set)
```

## Are there changes in behavior for the user?

No. It is not possible for the user to create a steam message containing no fields.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
