### PR TITLE
add noack to xreadgroup command

### DIFF
--- a/CHANGES/625.feature
+++ b/CHANGES/625.feature
@@ -1,0 +1,1 @@
+Added no_ack param to xread_group streams method in commands/streams.py

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -18,6 +18,7 @@ Dima Kruk
 Hugo <hugovk>
 Ihor Gorobets
 Ihor Liubymov
+Ilya Samartsev
 James Hilliard
 Jan Špaček
 Jeff Moser


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

adding noack param to xreadgroup command

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
