### PR TITLE
Optionally prepend an UNWATCH to a MULTI pipeline

### DIFF
--- a/CHANGES/636.feature
+++ b/CHANGES/636.feature
@@ -1,0 +1,2 @@
+Added an unwatch flag to redis.multi_exec() that pipelines an UNWATCH command to
+the beginning of the MULTI/EXEC.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -16,6 +16,7 @@ David Francos
 Dima Kruk
 <fuchaoqun>
 Hugo <hugovk>
+Ian Good
 Ihor Gorobets
 Ihor Liubymov
 James Hilliard

--- a/tests/transaction_commands_test.py
+++ b/tests/transaction_commands_test.py
@@ -251,6 +251,20 @@ async def test_transaction__watch_error(redis, create_redis, server, loop):
 
 
 @pytest.mark.run_loop
+async def test_transaction__unwatch(redis):
+    ok = await redis.watch('foo')
+    assert ok is True
+
+    ok = await redis.set('foo', 'foo')
+    assert ok is True
+
+    tr = redis.multi_exec(unwatch=True)
+    fut1 = tr.get('foo')
+    await tr.execute()
+    assert (await fut1) == b'foo'
+
+
+@pytest.mark.run_loop
 async def test_multi_exec_and_pool_release(redis):
     # Test the case when pool connection is released before
     # `exec` result is received.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Adds an `unwatch=True` keyword-only flag to `redis.multi_exec()` that adds an UNWATCH command to the beginning of the MULTI/EXEC pipeline. This can help in scenarios where it's difficult to ensure that UNWATCH was called after keys were WATCHed without a corresponding MULTI/EXEC, and pipelines to avoid an extra back-and-forth to the redis server.

## Are there changes in behavior for the user?

No, only the added keyword argument.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
