### PR TITLE
Change "@asyncio.coroutine" to "async def" due to warning in Python 3.8

### DIFF
--- a/CHANGES/648.misc
+++ b/CHANGES/648.misc
@@ -1,0 +1,1 @@
+Change "@asyncio.coroutine" to "async def" due to warning in Python 3.8

--- a/CHANGES/648.misc
+++ b/CHANGES/648.misc
@@ -1,1 +1,2 @@
 Change "@asyncio.coroutine" to "async def" due to warning in Python 3.8
+Fix tests for Python 3.8

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -44,5 +44,6 @@ Taras Voinarovskyi
 Thanos Lefteris
 Thomas Steinacher
 Volodymyr Hotsyk
+Youngmin Koo <youngminz>
 Dima Kit
 <curiouscod3>

--- a/aioredis/abc.py
+++ b/aioredis/abc.py
@@ -28,9 +28,8 @@ class AbcConnection(abc.ABC):
     def close(self):
         """Perform connection(s) close and resources cleanup."""
 
-    @asyncio.coroutine
     @abc.abstractmethod
-    def wait_closed(self):
+    async def wait_closed(self):
         """
         Coroutine waiting until all resources are closed/released/cleaned up.
         """
@@ -89,9 +88,8 @@ class AbcPool(AbcConnection):
         If no connection available — returns None.
         """
 
-    @asyncio.coroutine
     @abc.abstractmethod
-    def acquire(self):  # TODO: arguments
+    async def acquire(self):  # TODO: arguments
         """Acquires connection from pool."""
 
     @abc.abstractmethod
@@ -126,9 +124,8 @@ class AbcChannel(abc.ABC):
         """Flag indicating that channel has unreceived messages
         and not marked as closed."""
 
-    @asyncio.coroutine
     @abc.abstractmethod
-    def get(self):
+    async def get(self):
         """Wait and return new message.
 
         Will raise ``ChannelClosedError`` if channel is not active.

--- a/aioredis/abc.py
+++ b/aioredis/abc.py
@@ -3,7 +3,6 @@
 These are intended to be used for implementing custom connection managers.
 """
 import abc
-import asyncio
 
 
 __all__ = [

--- a/aioredis/abc.py
+++ b/aioredis/abc.py
@@ -88,11 +88,11 @@ class AbcPool(AbcConnection):
         """
 
     @abc.abstractmethod
-    async def acquire(self):  # TODO: arguments
+    async def acquire(self, command=None, args=()):
         """Acquires connection from pool."""
 
     @abc.abstractmethod
-    def release(self, conn):  # TODO: arguments
+    def release(self, conn):
         """Releases connection to pool.
 
         :param AbcConnection conn: Owned connection to be released.

--- a/aioredis/locks.py
+++ b/aioredis/locks.py
@@ -13,8 +13,7 @@ from asyncio.locks import Lock as _Lock
 class Lock(_Lock):
 
     if sys.version_info < (3, 7, 0):
-        @asyncio.coroutine
-        def acquire(self):
+        async def acquire(self):
             """Acquire a lock.
             This method blocks until the lock is unlocked, then sets it to
             locked and returns True.
@@ -27,7 +26,7 @@ class Lock(_Lock):
 
             self._waiters.append(fut)
             try:
-                yield from fut
+                await fut
                 self._locked = True
                 return True
             except asyncio.CancelledError:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
<!-- Please give a short brief about these changes. -->
Fixed: 
```
DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
```

## Are there changes in behavior for the user?
This should not be a problem if the user is using Python 3.5 or later.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
"@coroutine" decorator is deprecated since Python 3.8 #648
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist -- If all the existing test cases pass, that's fine.
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
