### PR TITLE
Fix transaction data decoding

### DIFF
--- a/CHANGES/657.bugfix
+++ b/CHANGES/657.bugfix
@@ -1,0 +1,1 @@
+Fix transaction data decoding

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -47,3 +47,4 @@ Volodymyr Hotsyk
 Youngmin Koo <youngminz>
 Dima Kit
 <curiouscod3>
+Dmitry Vasilishin <dmvass>

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -336,8 +336,10 @@ class RedisConnection(AbcConnection):
             cb = self._start_transaction
         elif command in ('EXEC', b'EXEC'):
             cb = partial(self._end_transaction, discard=False)
+            encoding = None
         elif command in ('DISCARD', b'DISCARD'):
             cb = partial(self._end_transaction, discard=True)
+            encoding = None
         else:
             cb = None
         if encoding is _NOTSET:

--- a/aioredis/connection.py
+++ b/aioredis/connection.py
@@ -339,7 +339,6 @@ class RedisConnection(AbcConnection):
             encoding = None
         elif command in ('DISCARD', b'DISCARD'):
             cb = partial(self._end_transaction, discard=True)
-            encoding = None
         else:
             cb = None
         if encoding is _NOTSET:

--- a/tests/transaction_commands_test.py
+++ b/tests/transaction_commands_test.py
@@ -215,13 +215,16 @@ async def test_global_encoding(redis, create_redis, server, loop):
     tr = redis.multi_exec()
     fut1 = tr.get('key')
     fut2 = tr.get('key', encoding='utf-8')
-    fut3 = tr.hgetall('hash-key', encoding='utf-8')
+    fut3 = tr.get('key', encoding=None)
+    fut4 = tr.hgetall('hash-key', encoding='utf-8')
     await tr.execute()
     res = await fut1
     assert res == 'value'
     res = await fut2
     assert res == 'value'
     res = await fut3
+    assert res == b'value'
+    res = await fut4
     assert res == {'foo': 'val1', 'bar': 'val2'}
 
 


### PR DESCRIPTION
## What do these changes do?

Fix incorrect transaction data decoding.

Transaction data always decoded two times if connection encoding was defined and impossible to override connection encoding per transaction command:

Test case:
```python
@pytest.mark.run_loop
async def test_global_encoding(redis, create_redis, server, loop):
    redis = await create_redis(
        server.tcp_address,
        loop=loop, encoding='utf-8')
    res = await redis.set('key', 'value')
    assert res is True
    res = await redis.hmset(
        'hash-key', 'foo', 'val1', 'bar', 'val2')
    assert res is True

    tr = redis.multi_exec()
    fut1 = tr.get('key')
    fut2 = tr.get('key', encoding='utf-8')
    fut3 = tr.get('key', encoding=None)
    fut4 = tr.hgetall('hash-key', encoding='utf-8')
    await tr.execute()
    res = await fut1
    assert res == 'value'
    res = await fut2
    assert res == 'value'
    res = await fut3
    assert res == b'value'
    res = await fut4
    assert res == {'foo': 'val1', 'bar': 'val2'}
```

Tracing for `util.decode`

**Before**
```python
decode(b'PONG', utf-8)
decode(b'OK', utf-8)
decode(b'OK', utf-8)
decode(b'OK', utf-8)
decode(b'QUEUED', utf-8)
decode(b'QUEUED', utf-8)
decode(b'QUEUED', utf-8)
decode([b'value', b'value', b'value', [b'foo', b'val1', b'bar', b'val2']], utf-8)
decode(b'value', utf-8)
decode(b'value', utf-8)
decode(b'value', utf-8)
decode([b'foo', b'val1', b'bar', b'val2'], utf-8)
decode(b'foo', utf-8)
decode(b'val1', utf-8)
decode(b'bar', utf-8)
decode(b'val2', utf-8)
decode(value, utf-8)
decode(value, utf-8)
decode(['foo', 'val1', 'bar', 'val2'], utf-8)
decode(foo, utf-8)
decode(val1, utf-8)
decode(bar, utf-8)
decode(val2, utf-8)
```

**After**
```python
decode(b'PONG', utf-8)
decode(b'OK', utf-8)
decode(b'OK', utf-8)
decode(b'OK', utf-8)
decode(b'QUEUED', utf-8)
decode(b'QUEUED', utf-8)
decode(b'QUEUED', utf-8)
decode(b'value', utf-8)
decode(b'value', utf-8)
decode([b'foo', b'val1', b'bar', b'val2'], utf-8)
decode(b'foo', utf-8)
decode(b'val1', utf-8)
decode(b'bar', utf-8)
decode(b'val2', utf-8)
```

## Are there changes in behavior for the user?

This changes should not impact on the end user.

## Related issue number

closes #657

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
