### PR TITLE
Fix duplicate calls to pool.wait_closed() upon create_pool() exception

### DIFF
--- a/aioredis/pool.py
+++ b/aioredis/pool.py
@@ -59,7 +59,6 @@ async def create_pool(address, *, db=None, password=None, ssl=None,
     except Exception:
         pool.close()
         await pool.wait_closed()
-        await pool.wait_closed()
         raise
     return pool
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Just a minor fix to remove a duplicate function call I have found while I'm reading the code.

## Are there changes in behavior for the user?

There should be nothing.
This code path is only taken when there are exceptions while creating a new Redis pool, which would rarely happen in normal use cases.

If this is an intended duplication, I think the authors should add a comment describing why.

## Related issue number

This is just a simple one-liner PR. :wink:

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
