### PR TITLE
Fix duplicate calls to pool.wait_closed() upon create_pool() exception

### DIFF
--- a/CHANGES/671.bugfix
+++ b/CHANGES/671.bugfix
@@ -1,0 +1,1 @@
+Fix duplicate calls to ``pool.wait_closed()`` upon ``create_pool()`` exception.

--- a/aioredis/pool.py
+++ b/aioredis/pool.py
@@ -59,7 +59,6 @@ async def create_pool(address, *, db=None, password=None, ssl=None,
     except Exception:
         pool.close()
         await pool.wait_closed()
-        await pool.wait_closed()
         raise
     return pool
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
