### PR TITLE
A simple redis lock implementation

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -11,6 +11,7 @@ Andrew Svetlov
 Anton Salii
 Anton Verinov
 Artem Mazur
+Brian Wright
 <cynecx>
 David Francos
 Dima Kruk

--- a/aioredis/commands/generic.py
+++ b/aioredis/commands/generic.py
@@ -340,7 +340,7 @@ class GenericCommandsMixin:
                      key.
             time: 5, thread-2 acquired `my-lock` now that it's available.
                      thread-2 sets the token to "xyz"
-            time: 6, thread-1 finishes its work and calls release(). if the
+            time: 6, thread-1 finishes its work and calls release(). If the
                      token is *not* stored in thread local storage, then
                      thread-1 would see the token value as "xyz" and would be
                      able to successfully release the thread-2's lock.

--- a/aioredis/commands/generic.py
+++ b/aioredis/commands/generic.py
@@ -1,3 +1,4 @@
+from aioredis.locks import RedisLock
 from aioredis.util import wait_convert, wait_ok, _NOTSET, _ScanIter
 
 
@@ -305,3 +306,55 @@ class GenericCommandsMixin:
         commands sent in the context of the current connection.
         """
         return self.execute(b'WAIT', numslaves, timeout)
+
+    def lock(self, name, *, timeout=None, sleep=0.1, blocking_timeout=None,
+             lock_class=None, thread_local=True):
+        """
+        Return a new Lock object using key ``name`` that mimics
+        the behavior of threading.Lock.
+
+        If specified, ``timeout`` indicates a maximum life for the lock.
+        By default, it will remain locked until release() is called.
+
+        ``sleep`` indicates the amount of time to sleep per loop iteration
+        when the lock is in blocking mode and another client is currently
+        holding the lock.
+
+        ``blocking_timeout`` indicates the maximum amount of time in seconds to
+        spend trying to acquire the lock. A value of ``None`` indicates
+        continue trying forever. ``blocking_timeout`` can be specified as a
+        float or integer, both representing the number of seconds to wait.
+
+        ``lock_class`` forces the specified lock implementation.
+
+        ``thread_local`` indicates whether the lock token is placed in
+        thread-local storage. By default, the token is placed in thread local
+        storage so that a thread only sees its token, not a token set by
+        another thread. Consider the following timeline:
+
+            time: 0, thread-1 acquires `my-lock`, with a timeout of 5 seconds.
+                     thread-1 sets the token to "abc"
+            time: 1, thread-2 blocks trying to acquire `my-lock` using the
+                     Lock instance.
+            time: 5, thread-1 has not yet completed. redis expires the lock
+                     key.
+            time: 5, thread-2 acquired `my-lock` now that it's available.
+                     thread-2 sets the token to "xyz"
+            time: 6, thread-1 finishes its work and calls release(). if the
+                     token is *not* stored in thread local storage, then
+                     thread-1 would see the token value as "xyz" and would be
+                     able to successfully release the thread-2's lock.
+
+        In some use cases it's necessary to disable thread local storage. For
+        example, if you have code where one thread acquires a lock and passes
+        that lock instance to a worker thread to release later. If thread
+        local storage isn't disabled in this case, the worker thread won't see
+        the token set by the thread that acquired the lock. Our assumption
+        is that these cases aren't common and as such default to using
+        thread local storage.
+        """
+        if lock_class is None:
+            lock_class = RedisLock
+        return lock_class(self, name, timeout=timeout, sleep=sleep,
+                          blocking_timeout=blocking_timeout,
+                          thread_local=thread_local)

--- a/aioredis/errors.py
+++ b/aioredis/errors.py
@@ -112,3 +112,11 @@ class ConnectionForcedCloseError(ConnectionClosedError):
 
 class PoolClosedError(RedisError):
     """Raised if pool is closed."""
+
+
+class LockError(RedisError):
+    """Errors acquiring or releasing a lock."""
+
+
+class LockNotOwnedError(LockError):
+    """Error trying to extend or release a lock that is (no longer) owned."""

--- a/aioredis/locks.py
+++ b/aioredis/locks.py
@@ -146,7 +146,7 @@ class RedisLock:
                      key.
             time: 5, thread-2 acquired `my-lock` now that it's available.
                      thread-2 sets the token to "xyz"
-            time: 6, thread-1 finishes its work and calls release(). if the
+            time: 6, thread-1 finishes its work and calls release(). If the
                      token is *not* stored in thread local storage, then
                      thread-1 would see the token value as "xyz" and would be
                      able to successfully release the thread-2's lock.

--- a/aioredis/locks.py
+++ b/aioredis/locks.py
@@ -240,11 +240,15 @@ class RedisLock:
         return False
 
     async def locked(self):
-        """Returns True if this key is locked by any process, otherwise False."""
+        """
+        Returns True if this key is locked by any process, otherwise False.
+        """
         return await self.redis.get(self.name, encoding='utf-8') is not None
 
     async def owned(self):
-        """Returns True if this key is locked by this lock, otherwise False."""
+        """
+        Returns True if this key is locked by this lock, otherwise False.
+        """
         stored_token = await self.redis.get(self.name, encoding='utf-8')
         return self.local.token is not None and \
             stored_token == self.local.token

--- a/aioredis/locks.py
+++ b/aioredis/locks.py
@@ -107,7 +107,8 @@ class RedisLock:
         return 1
     '''
 
-    def __init__(self, redis, name, *, timeout=None, sleep=0.1, blocking=True, blocking_timeout=None, thread_local=True):
+    def __init__(self, redis, name, *, timeout=None, sleep=0.1,
+                 blocking=True, blocking_timeout=None, thread_local=True):
         """
         Create a new Lock instance named ``name`` using the Redis client
         supplied by ``redis``.
@@ -181,7 +182,8 @@ class RedisLock:
     async def __aexit__(self, exc_type, exc, tb):
         await self.release()
 
-    async def acquire(self, *, blocking=None, blocking_timeout=None, token=None):
+    async def acquire(self, *, blocking=None, blocking_timeout=None,
+                      token=None):
         """
         Use Redis to hold a shared, distributed lock named ``name``.
         Returns True once the lock is acquired.
@@ -230,7 +232,9 @@ class RedisLock:
         else:
             timeout = None
 
-        if await self.redis.set(self.name, token, exist=self.redis.SET_IF_NOT_EXIST, pexpire=timeout):
+        if await self.redis.set(self.name, token,
+                                exist=self.redis.SET_IF_NOT_EXIST,
+                                pexpire=timeout):
             return True
 
         return False
@@ -242,7 +246,8 @@ class RedisLock:
     async def owned(self):
         """Returns True if this key is locked by this lock, otherwise False."""
         stored_token = await self.redis.get(self.name, encoding='utf-8')
-        return self.local.token is not None and stored_token == self.local.token
+        return self.local.token is not None and \
+            stored_token == self.local.token
 
     async def release(self):
         """Releases the already acquired lock."""
@@ -254,8 +259,11 @@ class RedisLock:
         await self.do_release(expected_token)
 
     async def do_release(self, expected_token):
-        if not bool(await self.redis.eval(self.LUA_RELEASE_SCRIPT, keys=[self.name], args=[expected_token])):
-            raise LockNotOwnedError("Cannot release a lock that's no longer owned")
+        if not bool(await self.redis.eval(self.LUA_RELEASE_SCRIPT,
+                                          keys=[self.name],
+                                          args=[expected_token])):
+            raise LockNotOwnedError("Cannot release a lock"
+                                    " that's no longer owned")
 
     async def extend(self, additional_time):
         """Adds more time to an already acquired lock.
@@ -273,8 +281,12 @@ class RedisLock:
 
     async def do_extend(self, additional_time):
         additional_time = int(additional_time * 1000)
-        if not bool(await self.redis.eval(self.LUA_EXTEND_SCRIPT, keys=[self.name], args=[self.local.token, additional_time])):
-            raise LockNotOwnedError("Cannot extend a lock that's no longer owned")
+        if not bool(await self.redis.eval(self.LUA_EXTEND_SCRIPT,
+                                          keys=[self.name],
+                                          args=[self.local.token,
+                                                additional_time])):
+            raise LockNotOwnedError("Cannot extend a lock"
+                                    " that's no longer owned")
 
         return True
 
@@ -290,7 +302,10 @@ class RedisLock:
 
     async def do_reacquire(self):
         timeout = int(self.timeout * 1000)
-        if not bool(await self.redis.eval(self.LUA_REACQUIRE_SCRIPT, keys=[self.name], args=[self.local.token, timeout])):
-            raise LockNotOwnedError("Cannot reacquire a lock that's no longer owned")
+        if not bool(await self.redis.eval(self.LUA_REACQUIRE_SCRIPT,
+                                          keys=[self.name],
+                                          args=[self.local.token, timeout])):
+            raise LockNotOwnedError("Cannot reacquire a lock"
+                                    " that's no longer owned")
 
         return True

--- a/aioredis/locks.py
+++ b/aioredis/locks.py
@@ -1,7 +1,12 @@
 import asyncio
 import sys
+import threading
+import time
+import uuid
 
 from asyncio.locks import Lock as _Lock
+
+from .errors import LockError, LockNotOwnedError
 
 # Fixes an issue with all Python versions that leaves pending waiters
 # without being awakened when the first waiter is canceled.
@@ -42,3 +47,250 @@ class Lock(_Lock):
                 if not fut.done():
                     fut.set_result(True)
                     break
+
+
+class dummy:
+    """Instances of this class can be used as an attribute container."""
+
+
+class RedisLock:
+    """
+    A shared, distributed Lock. Using Redis for locking allows the Lock
+    to be shared across processes and/or machines.
+
+    It's left to the user to resolve deadlock issues and make sure
+    multiple clients play nicely together.
+    """
+
+    # KEYS[1] - lock name
+    # ARGS[1] - token
+    # return 1 if the lock was released, otherwise 0
+    LUA_RELEASE_SCRIPT = '''
+        local token = redis.call('get', KEYS[1])
+        if not token or token ~= ARGV[1] then
+            return 0
+        end
+        redis.call('del', KEYS[1])
+        return 1
+    '''
+
+    # KEYS[1] - lock name
+    # ARGS[1] - token
+    # ARGS[2] - additional milliseconds
+    # return 1 if the locks time was extended, otherwise 0
+    LUA_EXTEND_SCRIPT = '''
+        local token = redis.call('get', KEYS[1])
+        if not token or token ~= ARGV[1] then
+            return 0
+        end
+        local expiration = redis.call('pttl', KEYS[1])
+        if not expiration then
+            expiration = 0
+        end
+        if expiration < 0 then
+            return 0
+        end
+        redis.call('pexpire', KEYS[1], expiration + ARGV[2])
+        return 1
+    '''
+
+    # KEYS[1] - lock name
+    # ARGS[1] - token
+    # ARGS[2] - milliseconds
+    # return 1 if the locks time was reacquired, otherwise 0
+    LUA_REACQUIRE_SCRIPT = '''
+        local token = redis.call('get', KEYS[1])
+        if not token or token ~= ARGV[1] then
+            return 0
+        end
+        redis.call('pexpire', KEYS[1], ARGV[2])
+        return 1
+    '''
+
+    def __init__(self, redis, name, *, timeout=None, sleep=0.1, blocking=True, blocking_timeout=None, thread_local=True):
+        """
+        Create a new Lock instance named ``name`` using the Redis client
+        supplied by ``redis``.
+
+        ``timeout`` indicates a maximum life for the lock.
+        By default, it will remain locked until release() is called.
+        ``timeout`` can be specified as a float or integer, both representing
+        the number of seconds to wait.
+
+        ``sleep`` indicates the amount of time to sleep per loop iteration
+        when the lock is in blocking mode and another client is currently
+        holding the lock.
+
+        ``blocking`` indicates whether calling ``acquire`` should block until
+        the lock has been acquired or to fail immediately, causing ``acquire``
+        to return False and the lock not being acquired. Defaults to True.
+        Note this value can be overridden by passing a ``blocking``
+        argument to ``acquire``.
+
+        ``blocking_timeout`` indicates the maximum amount of time in seconds to
+        spend trying to acquire the lock. A value of ``None`` indicates
+        continue trying forever. ``blocking_timeout`` can be specified as a
+        float or integer, both representing the number of seconds to wait.
+
+        ``thread_local`` indicates whether the lock token is placed in
+        thread-local storage. By default, the token is placed in thread local
+        storage so that a thread only sees its token, not a token set by
+        another thread. Consider the following timeline:
+
+            time: 0, thread-1 acquires `my-lock`, with a timeout of 5 seconds.
+                     thread-1 sets the token to "abc"
+            time: 1, thread-2 blocks trying to acquire `my-lock` using the
+                     Lock instance.
+            time: 5, thread-1 has not yet completed. redis expires the lock
+                     key.
+            time: 5, thread-2 acquired `my-lock` now that it's available.
+                     thread-2 sets the token to "xyz"
+            time: 6, thread-1 finishes its work and calls release(). if the
+                     token is *not* stored in thread local storage, then
+                     thread-1 would see the token value as "xyz" and would be
+                     able to successfully release the thread-2's lock.
+
+        In some use cases it's necessary to disable thread local storage. For
+        example, if you have code where one thread acquires a lock and passes
+        that lock instance to a worker thread to release later. If thread
+        local storage isn't disabled in this case, the worker thread won't see
+        the token set by the thread that acquired the lock. Our assumption
+        is that these cases aren't common and as such default to using
+        thread local storage.
+        """
+        self.redis = redis
+        self.name = name
+        self.timeout = timeout
+        self.sleep = sleep
+        self.blocking = blocking
+        self.blocking_timeout = blocking_timeout
+        self.thread_local = bool(thread_local)
+        self.local = threading.local() if self.thread_local else dummy()
+        self.local.token = None
+        if self.timeout and self.sleep > self.timeout:
+            raise LockError("'sleep' must be less than 'timeout'")
+
+    async def __aenter__(self):
+        # force blocking, as otherwise the user would have to check whether
+        # the lock was actually acquired or not.
+        if await self.acquire(blocking=True):
+            return self
+
+        raise LockError('Unable to acquire lock within the time specified')
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.release()
+
+    async def acquire(self, *, blocking=None, blocking_timeout=None, token=None):
+        """
+        Use Redis to hold a shared, distributed lock named ``name``.
+        Returns True once the lock is acquired.
+
+        If ``blocking`` is False, always return immediately. If the lock
+        was acquired, return True, otherwise return False.
+
+        ``blocking_timeout`` specifies the maximum number of seconds to
+        wait trying to acquire the lock.
+
+        ``token`` specifies the token value to be used. If provided, token
+        must be a string that be encoded using utf-8. If a token isn't
+        specified, a UUID will be generated.
+        """
+        sleep = self.sleep
+        if token is None:
+            token = uuid.uuid4().hex
+
+        if blocking is None:
+            blocking = self.blocking
+
+        if blocking_timeout is None:
+            blocking_timeout = self.blocking_timeout
+
+        stop_trying_at = None
+        if blocking_timeout is not None:
+            stop_trying_at = time.time() + blocking_timeout
+
+        while True:
+            if await self.do_acquire(token):
+                self.local.token = token
+                return True
+
+            if not blocking:
+                return False
+
+            if stop_trying_at is not None and time.time() > stop_trying_at:
+                return False
+
+            await asyncio.sleep(sleep)
+
+    async def do_acquire(self, token):
+        if self.timeout:
+            # convert to milliseconds
+            timeout = int(self.timeout * 1000)
+        else:
+            timeout = None
+
+        if await self.redis.set(self.name, token, exist=self.redis.SET_IF_NOT_EXIST, pexpire=timeout):
+            return True
+
+        return False
+
+    async def locked(self):
+        """Returns True if this key is locked by any process, otherwise False."""
+        return await self.redis.get(self.name, encoding='utf-8') is not None
+
+    async def owned(self):
+        """Returns True if this key is locked by this lock, otherwise False."""
+        stored_token = await self.redis.get(self.name, encoding='utf-8')
+        return self.local.token is not None and stored_token == self.local.token
+
+    async def release(self):
+        """Releases the already acquired lock."""
+        expected_token = self.local.token
+        if expected_token is None:
+            raise LockError('Cannot release an unlocked lock')
+
+        self.local.token = None
+        await self.do_release(expected_token)
+
+    async def do_release(self, expected_token):
+        if not bool(await self.redis.eval(self.LUA_RELEASE_SCRIPT, keys=[self.name], args=[expected_token])):
+            raise LockNotOwnedError("Cannot release a lock that's no longer owned")
+
+    async def extend(self, additional_time):
+        """Adds more time to an already acquired lock.
+
+        ``additional_time`` can be specified as an integer or a float, both
+        representing the number of seconds to add.
+        """
+        if self.local.token is None:
+            raise LockError('Cannot extend an unlocked lock')
+
+        if self.timeout is None:
+            raise LockError('Cannot extend a lock with no timeout')
+
+        return await self.do_extend(additional_time)
+
+    async def do_extend(self, additional_time):
+        additional_time = int(additional_time * 1000)
+        if not bool(await self.redis.eval(self.LUA_EXTEND_SCRIPT, keys=[self.name], args=[self.local.token, additional_time])):
+            raise LockNotOwnedError("Cannot extend a lock that's no longer owned")
+
+        return True
+
+    async def reacquire(self):
+        """Resets a TTL of an already acquired lock back to a timeout value."""
+        if self.local.token is None:
+            raise LockError('Cannot reacquire an unlocked lock')
+
+        if self.timeout is None:
+            raise LockError('Cannot reacquire a lock with no timeout')
+
+        return await self.do_reacquire()
+
+    async def do_reacquire(self):
+        timeout = int(self.timeout * 1000)
+        if not bool(await self.redis.eval(self.LUA_REACQUIRE_SCRIPT, keys=[self.name], args=[self.local.token, timeout])):
+            raise LockNotOwnedError("Cannot reacquire a lock that's no longer owned")
+
+        return True

--- a/tests/locks_test.py
+++ b/tests/locks_test.py
@@ -1,4 +1,6 @@
 import asyncio
+import pytest
+import time
 
 from aioredis.errors import LockError, LockNotOwnedError
 from aioredis.locks import Lock, RedisLock

--- a/tests/locks_test.py
+++ b/tests/locks_test.py
@@ -1,6 +1,7 @@
 import asyncio
 
-from aioredis.locks import Lock
+from aioredis.errors import LockError, LockNotOwnedError
+from aioredis.locks import Lock, RedisLock
 
 
 async def test_finished_waiter_cancelled():
@@ -28,3 +29,210 @@ async def test_finished_waiter_cancelled():
 
     await asyncio.sleep(0)
     assert lock.locked()
+
+
+async def test_lock(redis):
+    lock = RedisLock(redis, 'foo')
+    assert await lock.acquire(blocking=False)
+    assert await redis.get('foo', encoding='utf-8') == lock.local.token
+    assert await redis.ttl('foo') == -1
+    await lock.release()
+    assert await redis.get('foo', encoding='utf-8') is None
+
+
+async def test_lock_token(redis):
+    lock = RedisLock(redis, 'foo')
+    assert await lock.acquire(blocking=False, token='test')
+    assert await redis.get('foo', encoding='utf-8') == 'test'
+    assert lock.local.token == 'test'
+    assert await redis.ttl('foo') == -1
+    await lock.release()
+    assert await redis.get('foo', encoding='utf-8') is None
+    assert lock.local.token is None
+
+
+async def test_locked(redis):
+    lock = RedisLock(redis, 'foo')
+    assert await lock.locked() is False
+    await lock.acquire(blocking=False)
+    assert await lock.locked() is True
+    await lock.release()
+    assert await lock.locked() is False
+
+
+async def test_owned(redis):
+    lock = RedisLock(redis, 'foo')
+    assert await lock.owned() is False
+    await lock.acquire(blocking=False)
+    assert await lock.owned() is True
+    await lock.release()
+    assert await lock.owned() is False
+
+    lock2 = RedisLock(redis, 'foo')
+    assert await lock.owned() is False
+    assert await lock2.owned() is False
+    await lock2.acquire(blocking=False)
+    assert await lock.owned() is False
+    assert await lock2.owned() is True
+    await lock2.release()
+    assert await lock.owned() is False
+    assert await lock2.owned() is False
+
+
+async def test_competing_locks(redis):
+    lock1 = RedisLock(redis, 'foo')
+    lock2 = RedisLock(redis, 'foo')
+    assert await lock1.acquire(blocking=False)
+    assert not await lock2.acquire(blocking=False)
+    await lock1.release()
+    assert await lock2.acquire(blocking=False)
+    assert not await lock1.acquire(blocking=False)
+    await lock2.release()
+
+
+async def test_timeout(redis):
+    lock = RedisLock(redis, 'foo', timeout=10)
+    assert await lock.acquire(blocking=False)
+    assert 8 < await redis.ttl('foo') <= 10
+    await lock.release()
+
+
+async def test_float_timeout(redis):
+    lock = RedisLock(redis, 'foo', timeout=9.5)
+    assert await lock.acquire(blocking=False)
+    assert 8 < await redis.pttl('foo') <= 9500
+    await lock.release()
+
+
+async def test_blocking_timeout(redis):
+    lock1 = RedisLock(redis, 'foo')
+    assert await lock1.acquire(blocking=False)
+    lock2 = RedisLock(redis, 'foo', blocking_timeout=0.2)
+    start = time.time()
+    assert not await lock2.acquire()
+    assert (time.time() - start) > 0.2
+    await lock1.release()
+
+
+async def test_context_manager(redis):
+    # blocking_timeout prevents a deadlock if the lock can't be acquired
+    # for some reason
+    async with RedisLock(redis, 'foo', blocking_timeout=0.2) as lock:
+        assert await redis.get('foo', encoding='utf-8') == lock.local.token
+
+    assert await redis.get('foo', encoding='utf-8') is None
+
+
+async def test_context_manager_raises_when_lock_not_acquired(redis):
+    await redis.set('foo', 'bar')
+    with pytest.raises(LockError):
+        async with RedisLock(redis, 'foo', blocking_timeout=0.1):
+            pass  # pragma: no cover
+
+
+async def test_high_sleep_raises_error(redis):
+    # If sleep is higher than timeout, it should raise an error
+    with pytest.raises(LockError):
+        RedisLock(redis, 'foo', timeout=1, sleep=2)
+
+
+async def test_releasing_unlocked_lock_raises_error(redis):
+    lock = RedisLock(redis, 'foo')
+    with pytest.raises(LockError):
+        await lock.release()
+
+
+async def test_releasing_lock_no_longer_owned_raises_error(redis):
+    lock = RedisLock(redis, 'foo')
+    await lock.acquire(blocking=False)
+
+    # manually change the token
+    await redis.set('foo', 'a')
+    with pytest.raises(LockNotOwnedError):
+        await lock.release()
+
+    # even though we errored, the token is still cleared
+    assert lock.local.token is None
+
+
+async def test_extend_lock(redis):
+    lock = RedisLock(redis, 'foo', timeout=10)
+    assert await lock.acquire(blocking=False)
+    assert 8000 < await redis.pttl('foo') <= 10000
+    assert await lock.extend(10)
+    assert 16000 < await redis.pttl('foo') <= 20000
+    await lock.release()
+
+
+async def test_extend_lock_float(redis):
+    lock = RedisLock(redis, 'foo', timeout=10.0)
+    assert await lock.acquire(blocking=False)
+    assert 8000 < await redis.pttl('foo') <= 10000
+    assert await lock.extend(10.0)
+    assert 16000 < await redis.pttl('foo') <= 20000
+    await lock.release()
+
+
+async def test_extending_unlocked_lock_raises_error(redis):
+    lock = RedisLock(redis, 'foo', timeout=10)
+    with pytest.raises(LockError):
+        await lock.extend(10)
+
+
+async def test_extending_lock_with_no_timeout_raises_error(redis):
+    lock = RedisLock(redis, 'foo')
+    assert await lock.acquire(blocking=False)
+    with pytest.raises(LockError):
+        await lock.extend(10)
+
+    await lock.release()
+
+
+async def test_extending_lock_no_longer_owned_raises_error(redis):
+    lock = RedisLock(redis, 'foo', timeout=10)
+    assert await lock.acquire(blocking=False)
+    await redis.set('foo', 'a')
+    with pytest.raises(LockNotOwnedError):
+        await lock.extend(10)
+
+
+async def test_reacquire_lock(redis):
+    lock = RedisLock(redis, 'foo', timeout=10)
+    assert await lock.acquire(blocking=False)
+    assert await redis.pexpire('foo', 5000)
+    assert await redis.pttl('foo') <= 5000
+    assert await lock.reacquire()
+    assert 8000 < await redis.pttl('foo') <= 10000
+    await lock.release()
+
+
+async def test_reacquiring_unlocked_lock_raises_error(redis):
+    lock = RedisLock(redis, 'foo', timeout=10)
+    with pytest.raises(LockError):
+        await lock.reacquire()
+
+
+async def test_reacquiring_lock_with_no_timeout_raises_error(redis):
+    lock = RedisLock(redis, 'foo')
+    assert await lock.acquire(blocking=False)
+    with pytest.raises(LockError):
+        await lock.reacquire()
+
+    await lock.release()
+
+
+async def test_reacquiring_lock_no_longer_owned_raises_error(redis):
+    lock = RedisLock(redis, 'foo', timeout=10)
+    assert await lock.acquire(blocking=False)
+    await redis.set('foo', 'a')
+    with pytest.raises(LockNotOwnedError):
+        await lock.reacquire()
+
+
+async def test_lock_class_argument(redis):
+    class MyLock:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    lock = redis.lock('foo', lock_class=MyLock)
+    assert type(lock) == MyLock


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
This is a very simple redis distributed lock. The implementation was ported from [redis-py](https://github.com/andymccurdy/redis-py/blob/master/redis/lock.py).
There appears to be another PR (#573) that attempts to implement a similar lock, but it doesn't look like it has seen any activity for quite a while. So I'm opening a new PR for this feature.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
The change only adds additional functionality.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Mentioned in #43.

## Checklist

- [ ] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
