### PR TITLE
Stop removing `nil` messages in stream responses

### DIFF
--- a/CHANGES/723.bugfix
+++ b/CHANGES/723.bugfix
@@ -1,0 +1,1 @@
+Reveting fix to handling of instances were Redis returns null fields for a stream message. Nil values will now be returned.

--- a/aioredis/commands/streams.py
+++ b/aioredis/commands/streams.py
@@ -34,7 +34,6 @@ def parse_messages(messages):
     if messages is None:
         return []
 
-    messages = (message for message in messages if message is not None)
     return [
         (mid, fields_to_dict(values)) for mid, values in messages if values is not None
     ]

--- a/aioredis/commands/streams.py
+++ b/aioredis/commands/streams.py
@@ -31,12 +31,16 @@ def parse_messages(messages):
         ]
 
     """
-    if messages is None:
-        return []
+    parsed_messages = []
+    for message in messages:
+        if message is None:
+            # In some conditions redis will return a NIL message
+            parsed_messages.append((None, {}))
+        else:
+            mid, values = message
+            parsed_messages.append((mid, values))
 
-    return [
-        (mid, fields_to_dict(values)) for mid, values in messages if values is not None
-    ]
+    return parsed_messages
 
 
 def parse_messages_by_stream(messages_by_stream):

--- a/aioredis/commands/streams.py
+++ b/aioredis/commands/streams.py
@@ -38,7 +38,7 @@ def parse_messages(messages):
             parsed_messages.append((None, {}))
         else:
             mid, values = message
-            parsed_messages.append((mid, values))
+            parsed_messages.append((mid, fields_to_dict(values)))
 
     return parsed_messages
 

--- a/aioredis/commands/streams.py
+++ b/aioredis/commands/streams.py
@@ -38,6 +38,7 @@ def parse_messages(messages):
             parsed_messages.append((None, {}))
         else:
             mid, values = message
+            values = values or {}
             parsed_messages.append((mid, fields_to_dict(values)))
 
     return parsed_messages

--- a/tests/stream_commands_test.py
+++ b/tests/stream_commands_test.py
@@ -574,12 +574,12 @@ def test_parse_messages_ok():
 def test_parse_messages_null_fields():
     # Redis can sometimes respond with a fields value of 'null',
     # so ensure we handle that sensibly
-    message = [(b"123", None)]
-    assert parse_messages(message) == []
+    message = [(b'123', None)]
+    assert parse_messages(message) == [(b'123', OrderedDict())]
 
 
 def test_parse_messages_null_message():
     # Redis can sometimes respond with a fields value of 'null',
     # so ensure we handle that sensibly
     message = [None]
-    assert parse_messages(message) == []
+    assert parse_messages(message) == [(None, OrderedDict())]


### PR DESCRIPTION
I was the original author of this change some time ago (#605), and I now think it is a mistake. If redis decides to return `nil` values then I don't think `aioredis` should eat them.

In my case I am receiving `nil` values when performing an `XCLAIM`. Why does this happen? I'm not sure*, but I know that I definitely want to be able to `ACK` these `nil` messages in order to stop my consumer continually reclaiming them.

Removing of `nil` values by `aioredis` means the response I get looks like, "you could not claim this message," not the more accurate, "you claimed this message but there is no body".

* Perhaps they have been trimmed from the end of the stream but redis still sees them as claimed, so just returns `nil` rather than the message body.

Note that for now I am [monkey patching this](https://github.com/adamcharnock/lightbus/commit/93b767f45933a2e88ea8ed4f25b9c4b4690075f3) in [Lightbus](https://lightbus.org).

---

## What do these changes do?

This change stops the removal of `nil` values returned from the stream commands.

## Are there changes in behavior for the user?

As we don't really know why Redis returns `nil` values... maybe? See my speculation above.

## Related issue number

My original issue of #605 which added this issue in the first place.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes (there was no documentation for the original change in #605)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
