### PR TITLE
Fix some timeout tests for Python 3.8

### DIFF
--- a/tests/connection_test.py
+++ b/tests/connection_test.py
@@ -59,7 +59,9 @@ async def test_connect_inject_connection_cls_invalid(
 
 async def test_connect_tcp_timeout(request, create_connection, server):
     with patch('aioredis.connection.open_connection') as open_conn_mock:
-        open_conn_mock.side_effect = lambda *a, **kw: asyncio.sleep(0.2)
+        async def __side_effect(*a, **kw):
+            return await asyncio.sleep(0.2)
+        open_conn_mock.side_effect = __side_effect
         with pytest.raises(asyncio.TimeoutError):
             await create_connection(server.tcp_address, timeout=0.1)
 
@@ -84,7 +86,9 @@ async def test_connect_unixsocket(create_connection, server):
                     reason="No unixsocket on Windows")
 async def test_connect_unixsocket_timeout(create_connection, server):
     with patch('aioredis.connection.open_unix_connection') as open_conn_mock:
-        open_conn_mock.side_effect = lambda *a, **kw: asyncio.sleep(0.2)
+        async def __side_effect(*a, **kw):
+            return await asyncio.sleep(0.2)
+        open_conn_mock.side_effect = __side_effect
         with pytest.raises(asyncio.TimeoutError):
             await create_connection(server.unixsocket, db=0, timeout=0.1)
 

--- a/tests/pool_test.py
+++ b/tests/pool_test.py
@@ -15,7 +15,7 @@ from aioredis import (
     )
 from _testutils import redis_version
 
-BPO_34638 = sys.version_info >= (3, 8)
+BPO_34638 = (3, 8) < sys.version_info < (3, 8, 2)
 
 
 def _assert_defaults(pool):
@@ -59,7 +59,9 @@ async def test_maxsize(maxsize, create_pool, server):
 async def test_create_connection_timeout(create_pool, server):
     with patch('aioredis.connection.open_connection') as\
             open_conn_mock:
-        open_conn_mock.side_effect = lambda *a, **kw: asyncio.sleep(0.2)
+        async def __side_effect(*a, **kw):
+            return await asyncio.sleep(0.2)
+        open_conn_mock.side_effect = __side_effect
         with pytest.raises(asyncio.TimeoutError):
             await create_pool(
                 server.tcp_address,


### PR DESCRIPTION
## What do these changes do?

Some tests fails on Python 3.8 due to the side_effect being a lambda, that cannot be declared as async.

Also expectation for test_pool_idle_close do not match 3.8.2, so PBO_34638 was adjusted.

## Are there changes in behavior for the user?

No, only for tests.

## Related issue number

N/A
