### PR TITLE
fix NoneType object is not iterable when iterate over self._waiters

### DIFF
--- a/CHANGES/726.bugfix
+++ b/CHANGES/726.bugfix
@@ -1,0 +1,1 @@
+Fix "'NoneType' object is not iterable" when iterate over self._waiters.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -13,6 +13,7 @@ Anton Salii
 Anton Verinov
 Arsh <prdx23>
 Artem Mazur
+Chao Guo <jeffguorg>
 <cynecx>
 David Francos
 Dima Kruk

--- a/aioredis/locks.py
+++ b/aioredis/locks.py
@@ -19,7 +19,8 @@ class Lock(_Lock):
             This method blocks until the lock is unlocked, then sets it to
             locked and returns True.
             """
-            if not self._locked and all(w.cancelled() for w in self._waiters):
+            if (not self._locked and (self._waiters is None
+                                      or all(w.cancelled() for w in self._waiters))):
                 self._locked = True
                 return True
 

--- a/aioredis/locks.py
+++ b/aioredis/locks.py
@@ -40,7 +40,7 @@ class Lock(_Lock):
 
         def _wake_up_first(self):
             """Wake up the first waiter who isn't cancelled."""
-            for fut in self._waiters:
+            for fut in (self._waiters or []):
                 if not fut.done():
                     fut.set_result(True)
                     break

--- a/aioredis/locks.py
+++ b/aioredis/locks.py
@@ -20,7 +20,8 @@ class Lock(_Lock):
             locked and returns True.
             """
             if (not self._locked and (self._waiters is None
-                                      or all(w.cancelled() for w in self._waiters))):
+                                      or all(w.cancelled()
+                                             for w in self._waiters))):
                 self._locked = True
                 return True
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

#726 fix a problem lead by python3.8

## Are there changes in behavior for the user?

nope

## Related issue number

#726 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
