### PR TITLE
Fix docstring mistype in "zrevrangebylex"

### DIFF
--- a/aioredis/commands/sorted_set.py
+++ b/aioredis/commands/sorted_set.py
@@ -371,8 +371,8 @@ class SortedSetCommandsMixin:
         :raises TypeError: if min is not bytes
         :raises TypeError: if max is not bytes
         :raises TypeError: if both offset and count are not specified
-        :raises TypeError: if offset is not bytes
-        :raises TypeError: if count is not bytes
+        :raises TypeError: if offset is not int
+        :raises TypeError: if count is not int
         """
         if not isinstance(min, bytes):  # FIXME
             raise TypeError("min argument must be bytes")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fixes docstring mistypes in "zrevrangebylex"
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
