### PR TITLE
Replace pyup with Dependabot github native

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels:
+      - dependencies
+      - autosquash
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for Python
+  - package-ecosystem: "pip"
+    directory: "/"
+    labels:
+      - dependencies
+      - autosquash
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10

--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,3 +1,0 @@
-# Label PRs with `deps-update` label
-label_prs: deps-update
-branch: pyup


### PR DESCRIPTION
FYI.

I've dropped pyup (deleted the `/.pyup.yml` and unregistered the project on the pyup.io)

Dependabot is a native tool that is a part of GitHub now. 
I love dependabot, it allows rebuilding PRs created by the bot by `@dependabot recreate` and much more.

There are two dependabots actually: *preview* as it was on the moment of acquisition by GitHub and the *native*.

The *native* still has no *automerge* facility but @mjpieters it is solvable by an additional workflow that approves and merges dependabot's PRs if all checks are passed.

We can add this workflow later.