### PR TITLE
Fix asyncio.wait deprecation warning

### DIFF
--- a/aioredis/sentinel/pool.py
+++ b/aioredis/sentinel/pool.py
@@ -233,12 +233,8 @@ class SentinelPool:
             timeout = self.discover_timeout
         pools = []
         tasks = [self._connect_sentinel(addr, timeout, pools) for addr in self._sentinels]
-        done = await asyncio.gather(*tasks, return_exceptions=True)
+        await asyncio.gather(*tasks, return_exceptions=True)
 
-        for task in done:
-            result = task.result()
-            if isinstance(result, Exception):
-                continue  # FIXME
         if not pools:
             raise Exception("Could not connect to any sentinel")
         pools, self._pools[:] = self._pools[:], pools

--- a/aioredis/sentinel/pool.py
+++ b/aioredis/sentinel/pool.py
@@ -232,12 +232,9 @@ class SentinelPool:
         # TODO: discovery must be done with some customizable timeout.
         if timeout is None:
             timeout = self.discover_timeout
-        tasks = []
         pools = []
-        for addr in self._sentinels:  # iterate over unordered set
-            tasks.append(self._connect_sentinel(addr, timeout, pools))
-        done, pending = await asyncio.wait(tasks, return_when=ALL_COMPLETED)
-        assert not pending, ("Expected all tasks to complete", done, pending)
+        tasks = [self._connect_sentinel(addr, timeout, pools) for addr in self._sentinels]
+        done = await asyncio.gather(*tasks, return_exceptions=True)
 
         for task in done:
             result = task.result()

--- a/aioredis/sentinel/pool.py
+++ b/aioredis/sentinel/pool.py
@@ -1,7 +1,6 @@
 import asyncio
 import contextlib
 
-from concurrent.futures import ALL_COMPLETED
 from async_timeout import timeout as async_timeout
 
 from ..log import sentinel_logger


### PR DESCRIPTION
## What do these changes do?

Removes asyncio.wait usage in aioredis.sentinel.pool

(Please wait for some kind of CI to output)

Edit: I probably want to be on an IDE to make some of these changes and test them beforehand...

## Are there changes in behavior for the user?

No

## Related issue number

Fixes #789

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
