### PR TITLE
Add support for multiple field/value pairs to hset(), Fixes #705

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,6 +3,29 @@ Changes
 
 .. towncrier release notes start
 
+1.3.1 (2020-11-16)
+^^^^^^^^^^^^^^^^^^
+Features
+~~~~~~~~
+
+- Add support for client name in Connection/Pool objects to be set automatically upon connecting.
+  (see `#713 <https://github.com/aio-libs/aioredis/issues/713>`_);
+- Drop Python 3.5 support
+  (see `#824 <https://github.com/aio-libs/aioredis/issues/824>`_);
+
+Bugfixes
+~~~~~~~~
+
+- Add support for mapping with multiple field/value pairs to hset().
+  (see `#705 <https://github.com/aio-libs/aioredis/issues/705>`_);
+
+Misc
+~~~~
+
+- `#825 <https://github.com/aio-libs/aioredis/issues/825>`_,
+  `#840 <https://github.com/aio-libs/aioredis/issues/840>`_;
+
+
 1.3.1 (2019-12-02)
 ^^^^^^^^^^^^^^^^^^
 Bugfixes

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -3,29 +3,6 @@ Changes
 
 .. towncrier release notes start
 
-1.3.1 (2020-11-16)
-^^^^^^^^^^^^^^^^^^
-Features
-~~~~~~~~
-
-- Add support for client name in Connection/Pool objects to be set automatically upon connecting.
-  (see `#713 <https://github.com/aio-libs/aioredis/issues/713>`_);
-- Drop Python 3.5 support
-  (see `#824 <https://github.com/aio-libs/aioredis/issues/824>`_);
-
-Bugfixes
-~~~~~~~~
-
-- Add support for mapping with multiple field/value pairs to hset().
-  (see `#705 <https://github.com/aio-libs/aioredis/issues/705>`_);
-
-Misc
-~~~~
-
-- `#825 <https://github.com/aio-libs/aioredis/issues/825>`_,
-  `#840 <https://github.com/aio-libs/aioredis/issues/840>`_;
-
-
 1.3.1 (2019-12-02)
 ^^^^^^^^^^^^^^^^^^
 Bugfixes

--- a/CHANGES/705.bugfix
+++ b/CHANGES/705.bugfix
@@ -1,0 +1,1 @@
+Add support for mapping with multiple field/value pairs to hset().

--- a/CHANGES/705.removal
+++ b/CHANGES/705.removal
@@ -1,0 +1,1 @@
+Deprecate hmset() and hmset_dict(), use hset() instead.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR add in support to `hset()` to handle multiple field/value pairs, as redis 4.0.0 onwards `HSET` allows for multiple field/value pairs. In addition, `hmset()` and `hmset_dict()` are now deprecated.

I have followed the same convention as [redis-py](https://github.com/andymccurdy/redis-py/) and used the `mapping` keyword argument, I am happy to change it if needed.

redis docs reference:
`As of Redis 4.0.0, HSET is variadic and allows for multiple field/value pairs.`
 https://redis.io/commands/hset
`As per Redis 4.0.0, HMSET is considered deprecated. Please use HSET in new code.`
 https://redis.io/commands/hmset

pytest and flake8 tests passed locally.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

The api doesn't change for existing users, this only adds in additional support while keeping the previous methods working.
Also, calls to `hmset()` and `hmset_dict()` will now raise a deprecation warning.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes #705

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
