### PR TITLE
Increase delay in idle timeout unit test in an attempt to prevent it from failing on Travis CI

### DIFF
--- a/tests/connection_test.py
+++ b/tests/connection_test.py
@@ -491,7 +491,7 @@ async def test_connection_idle_close(create_connection, start_server):
     ok = await conn.execute("config", "set", "timeout", 1)
     assert ok == b"OK"
 
-    await asyncio.sleep(2)
+    await asyncio.sleep(6)
 
     with pytest.raises(ConnectionClosedError):
         assert await conn.execute("ping") is None


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Increased the delay in the unit test `test_connection_idle_close` by 3x. This is to give it a larger margin of error when running on Travis CI, as this test seems to fail arbitrarily when redis has not yet timed out by the time the delay is finished.

Relevant section from redis docs:
>Timeouts are not to be considered very precise: Redis avoids to set timer events or to run O(N) algorithms in order to check idle clients, so the check is performed incrementally from time to time. This means that it is possible that while the timeout is set to 10 seconds, the client connection will be closed, for instance, after 12 seconds if many clients are connected at the same time.

https://redis.io/topics/clients

I am not sure if this will definitely fix this issue, but i have made this pr to start the discussion, and also to see if the same test fails for this pr or not.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
None

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
None

## Checklist

- [x] I think the code is well written (nothing changed)
- [x] Unit tests for the changes exist (unit test itself was changed)
- [x] Documentation reflects the changes (no change needed)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
