### PR TITLE
Change Z*LEX APIs to pass min and max straight through

### DIFF
--- a/CHANGES/784.feature
+++ b/CHANGES/784.feature
@@ -1,0 +1,1 @@
+Z*LEX functions no longer take `include_min`/`include_max`, and the user must prefix the bounds with `[` or `(`, as per the [redis command](https://redis.io/commands/zrangebylex#how-to-specify-intervals).

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -13,6 +13,7 @@ Anton Salii
 Anton Verinov
 Arsh <prdx23>
 Artem Mazur
+Bruce Merry
 Chao Guo <jeffguorg>
 <cynecx>
 Daniil Kozhanov

--- a/aioredis/commands/sorted_set.py
+++ b/aioredis/commands/sorted_set.py
@@ -141,21 +141,10 @@ class SortedSetCommandsMixin:
         fut = self.execute(b"ZINTERSTORE", destkey, numkeys, *args)
         return fut
 
-    def zlexcount(self, key, min=b"-", max=b"+", include_min=True, include_max=True):
+    def zlexcount(self, key, min=b"-", max=b"+"):
         """Count the number of members in a sorted set between a given
         lexicographical range.
-
-        :raises TypeError: if min is not bytes
-        :raises TypeError: if max is not bytes
         """
-        if not isinstance(min, bytes):  # FIXME
-            raise TypeError("min argument must be bytes")
-        if not isinstance(max, bytes):  # FIXME     Why only bytes?
-            raise TypeError("max argument must be bytes")
-        if not min == b"-":
-            min = (b"[" if include_min else b"(") + min
-        if not max == b"+":
-            max = (b"[" if include_max else b"(") + max
         return self.execute(b"ZLEXCOUNT", key, min, max)
 
     def zrange(self, key, start=0, stop=-1, withscores=False, encoding=_NOTSET):
@@ -182,29 +171,16 @@ class SortedSetCommandsMixin:
         key,
         min=b"-",
         max=b"+",
-        include_min=True,
-        include_max=True,
         offset=None,
         count=None,
         encoding=_NOTSET,
     ):
         """Return a range of members in a sorted set, by lexicographical range.
 
-        :raises TypeError: if min is not bytes
-        :raises TypeError: if max is not bytes
         :raises TypeError: if both offset and count are not specified
-        :raises TypeError: if offset is not bytes
-        :raises TypeError: if count is not bytes
+        :raises TypeError: if offset is not int
+        :raises TypeError: if count is not int
         """
-        if not isinstance(min, bytes):  # FIXME
-            raise TypeError("min argument must be bytes")
-        if not isinstance(max, bytes):  # FIXME
-            raise TypeError("max argument must be bytes")
-        if not min == b"-":
-            min = (b"[" if include_min else b"(") + min
-        if not max == b"+":
-            max = (b"[" if include_max else b"(") + max
-
         if (offset is not None and count is None) or (
             count is not None and offset is None
         ):
@@ -273,23 +249,10 @@ class SortedSetCommandsMixin:
         """Remove one or more members from a sorted set."""
         return self.execute(b"ZREM", key, member, *members)
 
-    def zremrangebylex(
-        self, key, min=b"-", max=b"+", include_min=True, include_max=True
-    ):
+    def zremrangebylex(self, key, min=b"-", max=b"+"):
         """Remove all members in a sorted set between the given
         lexicographical range.
-
-        :raises TypeError: if min is not bytes
-        :raises TypeError: if max is not bytes
         """
-        if not isinstance(min, bytes):  # FIXME
-            raise TypeError("min argument must be bytes")
-        if not isinstance(max, bytes):  # FIXME
-            raise TypeError("max argument must be bytes")
-        if not min == b"-":
-            min = (b"[" if include_min else b"(") + min
-        if not max == b"+":
-            max = (b"[" if include_max else b"(") + max
         return self.execute(b"ZREMRANGEBYLEX", key, min, max)
 
     def zremrangebyrank(self, key, start, stop):
@@ -389,8 +352,6 @@ class SortedSetCommandsMixin:
         key,
         min=b"-",
         max=b"+",
-        include_min=True,
-        include_max=True,
         offset=None,
         count=None,
         encoding=_NOTSET,
@@ -398,21 +359,10 @@ class SortedSetCommandsMixin:
         """Return a range of members in a sorted set, by lexicographical range
         from high to low.
 
-        :raises TypeError: if min is not bytes
-        :raises TypeError: if max is not bytes
         :raises TypeError: if both offset and count are not specified
         :raises TypeError: if offset is not int
         :raises TypeError: if count is not int
         """
-        if not isinstance(min, bytes):  # FIXME
-            raise TypeError("min argument must be bytes")
-        if not isinstance(max, bytes):  # FIXME
-            raise TypeError("max argument must be bytes")
-        if not min == b"-":
-            min = (b"[" if include_min else b"(") + min
-        if not max == b"+":
-            max = (b"[" if include_max else b"(") + max
-
         if (offset is not None and count is None) or (
             count is not None and offset is None
         ):

--- a/tests/sorted_set_commands_test.py
+++ b/tests/sorted_set_commands_test.py
@@ -245,19 +245,10 @@ async def test_zlexcount(redis):
     assert res == 5
     res = await redis.zlexcount(key)
     assert res == 5
-    res = await redis.zlexcount(key, min=b"-", max=b"e")
+    res = await redis.zlexcount(key, min=b"-", max=b"[e")
     assert res == 5
-    res = await redis.zlexcount(
-        key, min=b"a", max=b"e", include_min=False, include_max=False
-    )
+    res = await redis.zlexcount(key, min=b"(a", max=b"(e")
     assert res == 3
-
-    with pytest.raises(TypeError):
-        await redis.zlexcount(None, b"a", b"e")
-    with pytest.raises(TypeError):
-        await redis.zlexcount(key, 10, b"e")
-    with pytest.raises(TypeError):
-        await redis.zlexcount(key, b"a", 20)
 
 
 @pytest.mark.parametrize("encoding", [None, "utf-8"])
@@ -307,24 +298,22 @@ async def test_zrangebylex(redis):
     assert res == members
     res = await redis.zrangebylex(key, encoding="utf-8")
     assert res == strings
-    res = await redis.zrangebylex(key, min=b"-", max=b"d")
+    res = await redis.zrangebylex(key, min=b"-", max=b"[d")
     assert res == members[:-1]
-    res = await redis.zrangebylex(
-        key, min=b"a", max=b"e", include_min=False, include_max=False
-    )
+    res = await redis.zrangebylex(key, min=b"(a", max=b"(e")
     assert res == members[1:-1]
-    res = await redis.zrangebylex(key, min=b"x", max=b"z")
+    res = await redis.zrangebylex(key, min=b"[x", max=b"[z")
     assert res == []
-    res = await redis.zrangebylex(key, min=b"e", max=b"a")
+    res = await redis.zrangebylex(key, min=b"[e", max=b"[a")
     assert res == []
     res = await redis.zrangebylex(key, offset=1, count=2)
     assert res == members[1:3]
     with pytest.raises(TypeError):
-        await redis.zrangebylex(None, b"a", b"e")
+        await redis.zrangebylex(None, b"[a", b"[e")
     with pytest.raises(TypeError):
-        await redis.zrangebylex(key, 10, b"e")
+        await redis.zrangebylex(key, None, b"[e")
     with pytest.raises(TypeError):
-        await redis.zrangebylex(key, b"a", 20)
+        await redis.zrangebylex(key, b"[a", None)
     with pytest.raises(TypeError):
         await redis.zrangebylex(key, b"a", b"e", offset=1)
     with pytest.raises(TypeError):
@@ -446,16 +435,12 @@ async def test_zremrangebylex(redis):
     res = await redis.zadd(key, *pairs)
     assert res == 10
 
-    res = await redis.zremrangebylex(
-        key, b"alpha", b"omega", include_max=True, include_min=True
-    )
+    res = await redis.zremrangebylex(key, b"[alpha", b"[omega")
     assert res == 6
     res = await redis.zrange(key, 0, -1)
     assert res == [b"ALPHA", b"aaaa", b"zap", b"zip"]
 
-    res = await redis.zremrangebylex(
-        key, b"zap", b"zip", include_max=False, include_min=False
-    )
+    res = await redis.zremrangebylex(key, b"(zap", b"(zip")
     assert res == 0
 
     res = await redis.zrange(key, 0, -1)
@@ -469,9 +454,9 @@ async def test_zremrangebylex(redis):
     with pytest.raises(TypeError):
         await redis.zremrangebylex(None, b"a", b"e")
     with pytest.raises(TypeError):
-        await redis.zremrangebylex(key, 10, b"e")
+        await redis.zremrangebylex(key, None, b"e")
     with pytest.raises(TypeError):
-        await redis.zremrangebylex(key, b"a", 20)
+        await redis.zremrangebylex(key, b"a", None)
 
 
 @pytest.mark.asyncio
@@ -710,24 +695,22 @@ async def test_zrevrangebylex(redis):
     assert res == rev_members
     res = await redis.zrevrangebylex(key, encoding="utf-8")
     assert res == rev_strings
-    res = await redis.zrevrangebylex(key, min=b"-", max=b"d")
+    res = await redis.zrevrangebylex(key, min=b"-", max=b"[d")
     assert res == rev_members[1:]
-    res = await redis.zrevrangebylex(
-        key, min=b"a", max=b"e", include_min=False, include_max=False
-    )
+    res = await redis.zrevrangebylex(key, min=b"(a", max=b"(e")
     assert res == rev_members[1:-1]
-    res = await redis.zrevrangebylex(key, min=b"x", max=b"z")
+    res = await redis.zrevrangebylex(key, min=b"[x", max=b"[z")
     assert res == []
-    res = await redis.zrevrangebylex(key, min=b"e", max=b"a")
+    res = await redis.zrevrangebylex(key, min=b"[e", max=b"[a")
     assert res == []
     res = await redis.zrevrangebylex(key, offset=1, count=2)
     assert res == rev_members[1:3]
     with pytest.raises(TypeError):
         await redis.zrevrangebylex(None, b"a", b"e")
     with pytest.raises(TypeError):
-        await redis.zrevrangebylex(key, 10, b"e")
+        await redis.zrevrangebylex(key, None, b"e")
     with pytest.raises(TypeError):
-        await redis.zrevrangebylex(key, b"a", 20)
+        await redis.zrevrangebylex(key, b"a", None)
     with pytest.raises(TypeError):
         await redis.zrevrangebylex(key, b"a", b"e", offset=1)
     with pytest.raises(TypeError):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This fixes #784 and eliminates the ambiguity where "-" could mean either
"from the beginning" or "from the literal string -". It is a breaking
API change.

## Are there changes in behavior for the user?

Yes. Users will need to prefix the `min` and `max` value with `[` or `(`.

## Related issue number

#784 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
