### PR TITLE
Remove references to Python 3.5 from the docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ Using a pool among multiple coroutine calls:
 Requirements
 ------------
 
-* Python_ 3.5.3+
+* Python_ 3.6+
 * hiredis_
 
 .. note::

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -675,7 +675,6 @@ Pub/Sub Channel object
          ...     print(msg)
 
       .. versionadded:: 0.2.5
-         Available for Python 3.5 only
 
 
 ----

--- a/docs/devel.rst
+++ b/docs/devel.rst
@@ -107,9 +107,6 @@ To run tests with :term:`uvloop`::
    $ pip install uvloop
    $ pytest --uvloop
 
-.. note:: Until Python 3.5.2 EventLoop has no ``create_future`` method
-   so aioredis won't benefit from uvloop's futures.
-
 
 Writing tests
 -------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,13 +25,13 @@ Pub/Sub support                     Yes
 Sentinel support                    Yes
 Redis Cluster support               WIP
 Trollius (python 2.7)               No
-Tested CPython versions             `3.5.3, 3.6, 3.7 <travis_>`_ [1]_
-Tested PyPy3 versions               `pypy3.5-7.0 pypy3.6-7.1.1 <travis_>`_
+Tested CPython versions             `3.6, 3.7, 3.8 <travis_>`_ [1]_
+Tested PyPy3 versions               `pypy3.6-7.1.1, pypy3.6-7.2.0 <travis_>`_
 Tested for Redis server             `2.6, 2.8, 3.0, 3.2, 4.0 5.0 <travis_>`_
 Support for dev Redis server        through low-level API
 ================================  ==============================
 
-.. [1] For Python 3.3, 3.4 support use aioredis v0.3.
+.. [1] For Python 3.5 support use aioredis v1.x. For Python 3.3, 3.4 support use aioredis v0.3.
 
 Installation
 ------------
@@ -43,7 +43,7 @@ The easiest way to install aioredis is by using the package on PyPi::
 Requirements
 ------------
 
-- Python 3.5.3+
+- Python 3.6+
 - :term:`hiredis`
 
 Benchmarks


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

9ab5f3f removed Python 3.5 support, but various bits of documentation
still said Python 3.5 was the minimum version.

## Are there changes in behavior for the user?

No.

## Related issue number

#824 

## Checklist

N/A. No code changes, and the CHANGES update is already done by #824.