### PR TITLE
Add support for TYPE argument of the SCAN command.

### DIFF
--- a/CHANGES/855.feature
+++ b/CHANGES/855.feature
@@ -1,0 +1,1 @@
+Add support for passing TYPE argument to the SCAN command.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -55,3 +55,4 @@ Dima Kit
 <curiouscod3>
 Dmitry Vasilishin <dmvass>
 Aviram Hassan <aviramha>
+Evgenii Morozov <emorozov>

--- a/aioredis/commands/generic.py
+++ b/aioredis/commands/generic.py
@@ -216,7 +216,7 @@ class GenericCommandsMixin:
         """Creates a key associated with a value that is obtained via DUMP."""
         return self.execute(b"RESTORE", key, ttl, value)
 
-    def scan(self, cursor=0, match=None, count=None):
+    def scan(self, cursor=0, match=None, count=None, key_type=None):
         """Incrementally iterate the keys space.
 
         Usage example:
@@ -234,6 +234,8 @@ class GenericCommandsMixin:
             args += [b"MATCH", match]
         if count is not None:
             args += [b"COUNT", count]
+        if key_type is not None:
+            args += [b"TYPE", key_type]
         fut = self.execute(b"SCAN", cursor, *args)
         return wait_convert(fut, lambda o: (int(o[0]), o[1]))
 

--- a/tests/generic_commands_test.py
+++ b/tests/generic_commands_test.py
@@ -607,6 +607,19 @@ async def test_scan(redis):
         test_values.extend(values)
     assert len(test_values) == 7
 
+    cursor, test_values = b"0", []
+    while cursor:
+        cursor, values = await redis.scan(cursor=cursor, match=b"key:scan:bar:*",
+                                          key_type=b"zset")
+        test_values.extend(values)
+    assert len(test_values) == 0
+
+    cursor, test_values = b"0", []
+    while cursor:
+        cursor, values = await redis.scan(cursor=cursor, key_type=b"string")
+        test_values.extend(values)
+    assert len(test_values) == 10
+
     # SCAN family functions do not guarantee that the number of
     # elements returned per call are in a given range. So here
     # just dummy test, that *count* argument does not break something


### PR DESCRIPTION
## What do these changes do?
Adds support for passing TYPE argument to the SCAN command.

## Related issue number

#855 