### PR TITLE
Add pre-commit autoupdate action

### DIFF
--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -1,0 +1,36 @@
+# Run pre-commit autoupdate every day at midnight
+# and create a pull request if any changes
+
+
+name: Pre-commit auto-update
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+  workflow_dispatch: # to trigger manually
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - name: Install pre-commit
+      run: pip install pre-commit
+
+    - name: Run pre-commit autoupdate
+      working-directory: "{{cookiecutter.project_slug}}"
+      run: pre-commit autoupdate
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v3.5.1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        branch: update/pre-commit-autoupdate
+        title: Auto-update pre-commit hooks
+        commit-message: Auto-update pre-commit hooks
+        body: Update versions of tools in pre-commit configs to latest version
+        labels: update


### PR DESCRIPTION
## What do these changes do?

Adds pre-commit autoupdate GitHub action. Taken from cookiecutter-django: * Taken from https://github.com/pydanny/cookiecutter-django/blob/master/.github/workflows/pre-commit-autoupdate.yml

If you would like automerge as well, then you would need another step that can take advantage of GitHub API from within the action.

## Are there changes in behavior for the user?

No

## Related issue number

#822 

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
