### PR TITLE
Fixed hanging pool when pubsub connection died

### DIFF
--- a/CHANGES/876.bugfix
+++ b/CHANGES/876.bugfix
@@ -1,0 +1,1 @@
+Fix pool hang when pubsub connection died.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -46,6 +46,7 @@ Oleksandr Tykhonruk
 Pau Freixes
 Paul Becotte
 Paul Colomiets
+Roman Ovsyannikov
 Samuel Colvin
 Samuel Dion-Girardeau
 Sean Stewart <seandstewart>

--- a/aioredis/pool.py
+++ b/aioredis/pool.py
@@ -270,6 +270,7 @@ class ConnectionsPool(AbcPool):
         if is_pubsub and self._pubsub_conn:
             if not self._pubsub_conn.closed:
                 return self._pubsub_conn, self._pubsub_conn.address
+            self._used.remove(self._pubsub_conn)
             self._pubsub_conn = None
         for i in range(self.freesize):
             conn = self._pool[0]


### PR DESCRIPTION
## What do these changes do?

Fixes hanging pool after pubsub connections died many times (more than pool size)

## Are there changes in behavior for the user?

no

## Related issue number

None

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
