### PR TITLE
fix pubsub pattern subscribe example

### DIFF
--- a/CHANGES/899.doc
+++ b/CHANGES/899.doc
@@ -1,0 +1,1 @@
+Fix pubsub example using PSUBSCRIBE to work as advertised.

--- a/aioredis/pubsub.py
+++ b/aioredis/pubsub.py
@@ -177,7 +177,7 @@ class Receiver:
     >>> await redis.subscribe(mpsc.channel('channel:1'),
     ...                       mpsc.channel('channel:3'))
     ...                       mpsc.channel('channel:5'))
-    >>> await redis.psubscribe(mpsc.pattern('hello'))
+    >>> await redis.psubscribe(mpsc.pattern('hello*'))
     >>> # publishing 'Hello world' into 'hello-channel'
     >>> # will print this message:
     Got b'Hello world' in channel b'hello-channel'


### PR DESCRIPTION
## What do these changes do?

I've just spend some time scratching my head over this, I initially assumed from the example that `mpsc.pattern()` automatically added the `*`.

## Are there changes in behavior for the user?

no

## Related issue number

no

## Checklist

- [x] I think the code is well written
- [ ] ~~Unit tests for the changes exist~~
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the [`CHANGES/`](../tree/master/CHANGES) folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example:
   `Fix issue with non-ascii contents in doctest text files.`
